### PR TITLE
Fix `gramschmidt` and `mvt`

### DIFF
--- a/polybench/gramschmidt.cpp
+++ b/polybench/gramschmidt.cpp
@@ -16,8 +16,8 @@ class Gramschmidt2;
 class Gramschmidt3;
 
 void init_array(DATA_TYPE* A, size_t size) {
-	const auto M = 0;
-	const auto N = 0;
+	const auto M = size;
+	const auto N = size;
 
 	for(size_t i = 0; i < M; i++) {
 		for(size_t j = 0; j < N; j++) {
@@ -27,8 +27,8 @@ void init_array(DATA_TYPE* A, size_t size) {
 }
 
 void gramschmidt(DATA_TYPE* A, DATA_TYPE* R, DATA_TYPE* Q, size_t size) {
-	const auto M = 0;
-	const auto N = 0;
+	const auto M = size;
+	const auto N = size;
 
 	for(size_t k = 0; k < N; k++) {
 		DATA_TYPE nrm = 0;

--- a/polybench/mvt.cpp
+++ b/polybench/mvt.cpp
@@ -19,8 +19,8 @@ void init_arrays(DATA_TYPE* a, DATA_TYPE* x1, DATA_TYPE* x2, DATA_TYPE* y_1, DAT
 	for(size_t i = 0; i < N; i++) {
 		x1[i] = 0.0;
 		x2[i] = 0.0;
-		y_1[i] = 0.0;
-		y_2[i] = 0.0;
+		y_1[i] = 1.0;
+		y_2[i] = 1.0;
 
 		for(size_t j = 0; j < N; j++) {
 			a[i * N + j] = (DATA_TYPE)(i + j + 1.0) / N;
@@ -101,6 +101,10 @@ class Polybench_Mvt {
 
 		std::vector<DATA_TYPE> x1_cpu(size);
 		std::vector<DATA_TYPE> x2_cpu(size);
+
+		// Trigger writeback
+		x1_buffer.reset();
+		x2_buffer.reset();
 
 		init_arrays(a.data(), x1_cpu.data(), x2_cpu.data(), y1.data(), y2.data(), size);
 


### PR DESCRIPTION
For `gramschmidt`, without the change in this PR, then `A` is actually not initialized, as the loop nest is never entered. It happens that elements of `A` are all zeros. In the kernels, when we do multiplication, reductions, etc on zeros, they will give us zeros. In the cpu code `gramschmidt()`, again loop nests are not entered, and elements of `A` continue to be zeros. End up we always verify even if we do nothing at all in the kernels.

For `mvt`, in the kernels `x1` and `x2` are calculated as `x1[i] += a[{i, j}] * y1[j];` and `x2[k] += a[{k, l}] * y2[l];`, if elements of `y1` and `y2` are always zeros, then elements of `x1` and `x2` are always zeros too. Given that elements of `x1` and `x2` are initialized to zeros, it always verify even if we do nothing at all in the kernels. It is also missing the writeback trigger before verification.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>