### PR TITLE
Revamp `nbody` verification

### DIFF
--- a/single-kernel/nbody.cpp
+++ b/single-kernel/nbody.cpp
@@ -107,10 +107,10 @@ public:
     }
 
     constexpr float_type maxErr = 10.f * std::numeric_limits<float_type>::epsilon();
-    return checkResults(
-               host_resulting_particles.begin(), host_resulting_particles.end(), resulting_particles.begin(), maxErr) &&
+    return checkResults(host_resulting_particles.begin(), host_resulting_particles.end(),
+               resulting_particles.get_pointer(), maxErr) &&
            checkResults(host_resulting_velocities.begin(), host_resulting_velocities.end(),
-               resulting_velocities.begin(), maxErr);
+               resulting_velocities.get_pointer(), maxErr);
   }
 
 protected:


### PR DESCRIPTION
Verification of this benchmark may fail for lower precision types as the underlying driver might replace the `sycl::rsqrt` builtin call with an `llvm.sqrt` intrinsic and an `fdiv` instruction for optimization levels other than `-O0`.

The new verification function does not depend on the number of inputs and uses relative error. Also, maximum allowed error depends on type precision now.