### PR TITLE
Add specialization constant convolution benchmark, other minor updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,10 +42,10 @@ if(SYCL_IMPL STREQUAL "ComputeCpp")
 elseif(SYCL_IMPL STREQUAL "hipSYCL")
   find_package(hipSYCL CONFIG REQUIRED)
 elseif(SYCL_IMPL STREQUAL "LLVM")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl -DSYCL2020_CONFORMANT_APIS -DSYCL2020_DISABLE_DEPRECATION_WARNINGS")
 elseif(SYCL_IMPL STREQUAL "LLVM-CUDA")
   set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice")
+    "${CMAKE_CXX_FLAGS} -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Wno-unknown-cuda-version -DSYCL2020_CONFORMANT_APIS -DSYCL2020_DISABLE_DEPRECATION_WARNINGS")
 elseif(SYCL_IMPL STREQUAL "triSYCL")
   find_package(TriSYCL MODULE REQUIRED)
 endif()
@@ -90,6 +90,7 @@ set(benchmarks
   polybench/syr2k.cpp
   polybench/syrk.cpp
   #compiletime/compiletime.cpp
+  spec_constants/spec_constant_convolution.cpp
 )
 
 foreach(benchmark IN LISTS benchmarks)

--- a/include/prefetched_buffer.h
+++ b/include/prefetched_buffer.h
@@ -44,11 +44,13 @@ public:
 
   void initialize(cl::sycl::queue& q, T* data, cl::sycl::range<Dimensions> r) {
     buff = std::make_shared<cl::sycl::buffer<T, Dimensions>>(data, r);
+    buff->set_write_back(false);
     forceDataTransfer(q, *buff);
   }
 
   void initialize(cl::sycl::queue& q, const T* data, cl::sycl::range<Dimensions> r) {
     buff = std::make_shared<cl::sycl::buffer<T, Dimensions>>(data, r);
+    buff->set_write_back(false);
     forceDataTransfer(q, *buff);
   }
 

--- a/include/time_metrics.h
+++ b/include/time_metrics.h
@@ -77,6 +77,20 @@ public:
         std::vector<double> resultsSeconds;
         std::transform(timingResults.at(name).begin(), timingResults.at(name).end(), std::back_inserter(resultsSeconds),
             [](auto r) { return r.count() / 1.0e9; });
+
+        // Emit individual samples as well
+        // do this before sorting, since sometimes there might be a noteworthy pattern in the temporal order
+        std::stringstream samples;
+        samples << "\"";
+        for(int i = 0; i < resultsSeconds.size(); ++i) {
+          samples << std::to_string(resultsSeconds[i]);
+          if(i != resultsSeconds.size() - 1) {
+            samples << " ";
+          }
+        }
+        samples << "\"";
+        consumer.consumeResult(name + "-samples", samples.str());
+
         std::sort(resultsSeconds.begin(), resultsSeconds.end());
 
         double mean = std::accumulate(resultsSeconds.begin(), resultsSeconds.end(), 0.0) /
@@ -100,18 +114,6 @@ public:
         consumer.consumeResult(name + "-stddev", std::to_string(stddev), "s");
         consumer.consumeResult(name + "-median", std::to_string(median), "s");
         consumer.consumeResult(name + "-min", std::to_string(resultsSeconds[0]), "s");
-
-        // Emit individual samples as well
-        std::stringstream samples;
-        samples << "\"";
-        for(int i = 0; i < resultsSeconds.size(); ++i) {
-          samples << std::to_string(resultsSeconds[i]);
-          if(i != resultsSeconds.size() - 1) {
-            samples << " ";
-          }
-        }
-        samples << "\"";
-        consumer.consumeResult(name + "-samples", samples.str());
 
         double throughputMetric = 0.0;
         double throughput = 0.0;

--- a/include/type_traits.h
+++ b/include/type_traits.h
@@ -8,7 +8,7 @@ struct ReadableTypename
 #define MAKE_READABLE_TYPENAME(T, str) \
 template<> \
 struct ReadableTypename<T> \
-{ static const char* name; }; const char* ReadableTypename<T>::name = str;
+{ inline static const char* name = str; };
 
 MAKE_READABLE_TYPENAME(char, "int8")
 MAKE_READABLE_TYPENAME(unsigned char, "uint8")

--- a/spec_constants/spec_constant_convolution.cpp
+++ b/spec_constants/spec_constant_convolution.cpp
@@ -1,0 +1,193 @@
+// Specialization constant benchmark
+// - runs a generic 9 point stencil of which only 5 points are used in practice
+// - weights are provided either 
+//   * fully dynamically (AccessVariants::dynamic_value),
+//   * as specialization constants (AccessVariants::spec_const_value), or
+//   * statically at compile time (AccessVariants::constexpr_value)
+// Example run: ./spec_constant_convolution --device=gpu --no-verification --size=8192 --output=out.csv
+
+#include "common.h"
+#include <iostream>
+
+enum class AccessVariants {
+  dynamic_value,
+  spec_const_value,
+  constexpr_value,
+};
+
+namespace s = cl::sycl;
+template <typename T, AccessVariants AccessVariant, int InnerLoops> class ConvKernel;
+
+// T is the data type operated on
+// AccessVariant determines if coefficients are accessed dynamically, use specialization constants, or are static
+// InnerLoops allows tuning the arithmetic intensity of the kernel
+template <typename T, AccessVariants AccessVariant, int InnerLoops>
+class SpecConstConvBench
+{
+  int problem_size = 1;
+
+  using coeff_t = std::array<std::array<T, 3>, 3>;
+
+  // internal function to generate some coefficients for the specialization constant
+  coeff_t getCoefficients() {
+    // trick the compiler a bit - problem size is always < 0, but the compiler doesn't know that
+    T val( problem_size < 0 ? problem_size : 2);
+    T val0( problem_size < 0 ? problem_size : 0);
+    return {{{val0,val,val0},{val,val,val},{val0,val,val0}}};
+  }
+
+  T getDivider() {
+    // analogous to above
+    return problem_size < 0 ? T(problem_size) : T(5);
+  }
+
+  T getInitValue() {
+    // analogous to above
+    return problem_size < 0 ? T(problem_size) : T(1);
+  }
+
+  // ids for the specialization constants
+  static constexpr s::specialization_id<coeff_t> coeff_id;
+  static constexpr s::specialization_id<T> div_id;
+
+  BenchmarkArgs args;
+
+  PrefetchedBuffer<T, 2> in_buf;
+  PrefetchedBuffer<T, 2> out_buf;
+
+  std::vector<T> in_vec;
+
+public:
+  SpecConstConvBench(const BenchmarkArgs &_args) : args(_args) {}
+
+  void setup() {
+    problem_size = (int)args.problem_size;
+
+    in_vec.resize(problem_size * problem_size);
+    std::fill(in_vec.begin(), in_vec.end(), getInitValue());
+
+    in_buf.initialize(args.device_queue, in_vec.data(), s::range<2>(problem_size, problem_size));
+    out_buf.initialize(args.device_queue, in_vec.data(), s::range<2>(problem_size, problem_size));
+  }
+
+  void run(std::vector<cl::sycl::event>& events) {
+    events.push_back(args.device_queue.submit([&](cl::sycl::handler& cgh) {
+      auto in = in_buf.template get_access<s::access::mode::read>(cgh);
+      auto out = out_buf.template get_access<s::access::mode::write>(cgh);
+
+      // set the specialization constants
+      coeff_t dynamic_coeff;
+      T dynamic_div;
+      if constexpr(AccessVariant == AccessVariants::dynamic_value) {
+        dynamic_coeff = getCoefficients();
+        dynamic_div = getDivider();
+      }
+      else if constexpr(AccessVariant == AccessVariants::spec_const_value) {
+        cgh.set_specialization_constant<coeff_id>(getCoefficients());
+        cgh.set_specialization_constant<div_id>(getDivider());
+      }
+
+      cgh.parallel_for<class ConvKernel<T, AccessVariant, InnerLoops>>(
+          in.get_range(), [=](s::item<2> item_id, s::kernel_handler h) {
+            T acc = 0;
+            coeff_t coeff;
+            T div;
+            if constexpr(AccessVariant == AccessVariants::dynamic_value) {
+              coeff = dynamic_coeff;
+              div = dynamic_div;
+            }
+            else if constexpr(AccessVariant == AccessVariants::spec_const_value) {
+              coeff = h.get_specialization_constant<coeff_id>();
+              div = h.get_specialization_constant<div_id>();
+            }
+            else if constexpr(AccessVariant == AccessVariants::constexpr_value) {
+              coeff = {{{0,2,0},{2,2,2},{0,2,0}}};
+              div = 5;
+            }
+            for(int k = 0; k < InnerLoops; ++k) {
+              for (int i = -1; i <= 1; i++) {
+                if (item_id[0] + i < 0 || item_id[0] + i >= in.get_range()[0]) continue;
+                for (int j = -1; j <= 1; j++) {
+                  if (item_id[1] + j < 0 || item_id[1] + j >= out.get_range()[1]) continue;
+                  acc += coeff[i + 1][j + 1] * in[item_id[0] + i][item_id[1] + j];
+                }
+              }
+            }
+            out[item_id] = acc / (div * T(InnerLoops));
+        });
+    }));
+  }
+
+  bool verify(VerificationSetting &ver) {
+    auto out_acc = out_buf.template get_access<s::access::mode::read>();
+
+    bool pass = true;
+
+    auto c = getCoefficients();
+    auto d = getDivider();
+    auto v = getInitValue();
+    T expected_val = 0;
+    for(int i=0; i<InnerLoops; ++i) {
+      expected_val += v*c[0][0] + v*c[0][1] + v*c[0][2] //
+                    + v*c[1][0] + v*c[1][1] + v*c[1][2] //
+                    + v*c[2][0] + v*c[2][1] + v*c[2][2] ;
+    }
+    expected_val /= d*InnerLoops;
+
+    for(size_t x = 1; x < args.problem_size-1 && pass; ++x) {
+      for(size_t y = 1; y < args.problem_size-1 && pass; ++y) {
+
+        if(out_acc[x][y] != expected_val) {
+          std::cout << "Fail at = " << x << " / " << y
+                    << "\nExpected = " << expected_val << "Actual =" << out_acc[x][y] << std::endl;
+          pass = false;
+          break;
+        }
+      }
+    }
+
+    return pass;
+  }
+
+  static std::string getBenchmarkName() {
+    std::stringstream name;
+    name << "SpecConstantConvolution_";
+    name << ReadableTypename<T>::name;
+    if constexpr(AccessVariant == AccessVariants::dynamic_value) {
+      name << "_DynamicValue";
+    }
+    else if constexpr(AccessVariant == AccessVariants::spec_const_value) {
+      name << "_SpecConstValue";
+    }
+    else if constexpr(AccessVariant == AccessVariants::constexpr_value) {
+      name << "_ConstExprValue";
+    }
+    name << "_IL" << InnerLoops;
+    return name.str();
+  }
+};
+
+
+template<typename T, AccessVariants AccessVariant>
+void runLoopCounts(BenchmarkApp& app) {
+  app.run<SpecConstConvBench<T, AccessVariant, 1>>();
+  app.run<SpecConstConvBench<T, AccessVariant, 16>>();
+  app.run<SpecConstConvBench<T, AccessVariant, 64>>();
+}
+
+template<typename T>
+void runAccessVariants(BenchmarkApp& app) {
+  runLoopCounts<T, AccessVariants::dynamic_value>(app);
+  runLoopCounts<T, AccessVariants::spec_const_value>(app);
+  runLoopCounts<T, AccessVariants::constexpr_value>(app);
+}
+
+int main(int argc, char** argv)
+{
+  BenchmarkApp app(argc, argv);
+  runAccessVariants<int>(app);
+  runAccessVariants<long long>(app);
+  runAccessVariants<float>(app);
+  runAccessVariants<double>(app);
+  return 0;
+}


### PR DESCRIPTION
This PR adds a benchmark which measures the performance impact of specialization constants.
Note that it also includes minor updates to the build process, and to the way results are printed.

## Benchmark Principle

The benchmark runs a basic 2D convolution with a generic 3x3 stencil, of which only 5 points are non-zero.  
This seems like a good approximation of a useful and representative use case to me.

In order to better interpret the quality of the results, the following **ways to specify weights** are included:
1. fully dynamically (`AccessVariants::dynamic_value`),
2. as specialization constants (`AccessVariants::spec_const_value`), or
3. statically at compile time (`AccessVariants::constexpr_value`)

Of these, the expectation would be for option 1. to serve as an upper boundary on execution time, and option 3. to be the lower boundary.

The benchmark is also templated across the **data type** of the computation, and an **inner loop count `IL`**. The latter serves the purpose of varying the overall execution time and arithmetic intensity of the kernel.

## Results & Discussion

The results turned out to be somewhat more interesting than initially suspected.  
What follows are a subset of the measurements on 2 different architectures (and backends), 15 runs each, medians reported.
### RTX 3090, using the DPCPP CUDA backend
![3090_int64](https://github.com/unisa-hpc/sycl-bench/assets/1033475/ef45ba82-c4ce-4413-aab0-e78816032ca6)
![3090_fp64](https://github.com/unisa-hpc/sycl-bench/assets/1033475/c86bafce-8af1-4aaa-ab12-9c68d78501a4)

Potential conclusions from this data:

- For the CUDA backend, it seems like there is significant optimization potential for the compiler if it knows the values of `int64`s, but not `fp64`s.
- Specialization constants do not appear to be implemented.
	- In fact, for `IL1` there is a small performance overhead. This indicates that using specialization constants (which appear to be simply a wrapper around dynamic variables) has a small fixed overhead, the impact of which is diminished for the longer-runnign `IL16`+ versions.

### Intel ARC 770, using the DPCPP Intel backend
![770_int64](https://github.com/unisa-hpc/sycl-bench/assets/1033475/74b044f3-89e2-4b97-b98a-12c5907c5f8c)
![770_fp32](https://github.com/unisa-hpc/sycl-bench/assets/1033475/3658b34d-d6b2-4aa4-b348-79d70e9e849e)

Potential conclusions from this data:

- Clearly, *something* happens for specialization constants, other than simply wrapping dynamic data.
- Non-obvious compiler heuristics appear to be involved: for `int64` only `IL1` is affected, while for `fp32` `IL16` is disproportionally optimized by using specialization constants.
	- The latter achieves a result **superior to offline compilation**, which is quite surprising.


### Per-run Execution Times

To further support the conclusions drawn from these results, consider these relative per-run execution times:
![per_run](https://github.com/unisa-hpc/sycl-bench/assets/1033475/9dce9e1e-3715-4089-b6dc-70c1d57e01df)

We observe the following:
- On the CUDA backend, the initial run behaves exactly the same as every other run, consistent with offline ahead-of-time compilation.
- On the Intel backend, even without using specialization constants, the initial run is slightly longer, perhaps indicating some instantiation / final compilation pass overhead. More importantly, when using specialization constants, there is a **large overhead which is independent of the kernel execution time**. This is consistent with a compilation infrastructure being spun up and applied.