### PR TITLE
Enable FP64 benchmarks at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ endif()
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_SOURCE_DIR}/polybench/common)
 
+# SYCL Bench variables
+set(SYCL_BENCH_ENABLE_FP64_BENCHMARKS "ON" CACHE STRING "Enable FP64 benchmarks [ON]")
+
 set(supported_implementations
   AdaptiveCpp
   dpcpp
@@ -115,6 +118,9 @@ set(benchmarks
   # compiletime/compiletime.cpp
   spec_constants/spec_constant_convolution.cpp
 )
+
+# Setting variables
+add_compile_definitions(SYCL_BENCH_ENABLE_FP64_BENCHMARKS=$<BOOL:${SYCL_BENCH_ENABLE_FP64_BENCHMARKS}>)
 
 foreach(benchmark IN LISTS benchmarks)
   get_filename_component(target ${benchmark} NAME_WE)

--- a/micro/DRAM.cpp
+++ b/micro/DRAM.cpp
@@ -102,11 +102,12 @@ int main(int argc, char** argv) {
   app.run<MicroBenchDRAM<float, 1>>();
   app.run<MicroBenchDRAM<float, 2>>();
   app.run<MicroBenchDRAM<float, 3>>();
-  if(app.deviceSupportsFP64()) {
-    app.run<MicroBenchDRAM<double, 1>>();
-    app.run<MicroBenchDRAM<double, 2>>();
-    app.run<MicroBenchDRAM<double, 3>>();
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64()) {
+      app.run<MicroBenchDRAM<double, 1>>();
+      app.run<MicroBenchDRAM<double, 2>>();
+      app.run<MicroBenchDRAM<double, 3>>();
+    }
   }
-
   return 0;
 }

--- a/micro/arith.cpp
+++ b/micro/arith.cpp
@@ -91,8 +91,9 @@ int main(int argc, char** argv) {
 
   app.run<MicroBenchArithmetic<int>>();
   app.run<MicroBenchArithmetic<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<MicroBenchArithmetic<double>>();
-
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<MicroBenchArithmetic<double>>();
+  }
   return 0;
 }

--- a/micro/local_mem.cpp
+++ b/micro/local_mem.cpp
@@ -100,8 +100,9 @@ int main(int argc, char** argv) {
   app.run<MicroBenchLocalMemory<float, compute_iters>>();
 
   // double precision
-  if(app.deviceSupportsFP64())
-    app.run<MicroBenchLocalMemory<double, compute_iters>>();
-
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<MicroBenchLocalMemory<double, compute_iters>>();
+  }
   return 0;
 }

--- a/micro/pattern_L2.cpp
+++ b/micro/pattern_L2.cpp
@@ -71,14 +71,16 @@ int main(int argc, char** argv) {
   app.run<MicroBenchL2<float, 8>>();
   app.run<MicroBenchL2<float, 16>>();
 
-  // double precision
-  if(app.deviceSupportsFP64()) {
-    app.run<MicroBenchL2<double, 1>>();
-    app.run<MicroBenchL2<double, 2>>();
-    app.run<MicroBenchL2<double, 4>>();
-    app.run<MicroBenchL2<double, 8>>();
-    app.run<MicroBenchL2<double, 16>>();
-  }
 
+  // double precision
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64()) {
+      app.run<MicroBenchL2<double, 1>>();
+      app.run<MicroBenchL2<double, 2>>();
+      app.run<MicroBenchL2<double, 4>>();
+      app.run<MicroBenchL2<double, 8>>();
+      app.run<MicroBenchL2<double, 16>>();
+    }
+  }
   return 0;
 }

--- a/micro/sf.cpp
+++ b/micro/sf.cpp
@@ -85,8 +85,9 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
 
   app.run<MicroBenchSpecialFunc<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<MicroBenchSpecialFunc<double>>();
-
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<MicroBenchSpecialFunc<double>>();
+  }
   return 0;
 }

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -171,8 +171,7 @@ private:
 template <class T>
 class ReductionNDRange : public Reduction<T> {
 public:
-  ReductionNDRange(const BenchmarkArgs& args) : Reduction<T> { args }
-  {}
+  ReductionNDRange(const BenchmarkArgs& args) : Reduction<T>{args} {}
 
   void run(std::vector<sycl::event>& events) { this->submit_ndrange(events); }
 
@@ -187,8 +186,7 @@ public:
 template <class T>
 class ReductionHierarchical : public Reduction<T> {
 public:
-  ReductionHierarchical(const BenchmarkArgs& args) : Reduction<T> { args }
-  {}
+  ReductionHierarchical(const BenchmarkArgs& args) : Reduction<T>{args} {}
 
   void run(std::vector<sycl::event>& events) {
     this->submit_hierarchical(events);
@@ -214,15 +212,18 @@ int main(int argc, char** argv) {
     app.run<ReductionNDRange<int>>();
     app.run<ReductionNDRange<long long>>();
     app.run<ReductionNDRange<float>>();
-    if(app.deviceSupportsFP64())
-      app.run<ReductionNDRange<double>>();
+    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+      if(app.deviceSupportsFP64())
+        app.run<ReductionNDRange<double>>();
+    }
   }
   // app.run< ReductionHierarchical<short>>();
   app.run<ReductionHierarchical<int>>();
   app.run<ReductionHierarchical<long long>>();
   app.run<ReductionHierarchical<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<ReductionHierarchical<double>>();
-
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<ReductionHierarchical<double>>();
+  }
   return 0;
 }

--- a/pattern/segmentedreduction.cpp
+++ b/pattern/segmentedreduction.cpp
@@ -127,8 +127,7 @@ public:
 template <class T>
 class SegmentedReductionNDRange : public SegmentedReduction<T> {
 public:
-  SegmentedReductionNDRange(const BenchmarkArgs& args) : SegmentedReduction<T> { args }
-  {}
+  SegmentedReductionNDRange(const BenchmarkArgs& args) : SegmentedReduction<T>{args} {}
 
   void run(std::vector<sycl::event>& events) {
     this->submit_ndrange(events);
@@ -147,8 +146,7 @@ public:
 template <class T>
 class SegmentedReductionHierarchical : public SegmentedReduction<T> {
 public:
-  SegmentedReductionHierarchical(const BenchmarkArgs& args) : SegmentedReduction<T> { args }
-  {}
+  SegmentedReductionHierarchical(const BenchmarkArgs& args) : SegmentedReduction<T>{args} {}
 
   void run(std::vector<sycl::event>& events) {
     this->submit_hierarchical(events);
@@ -172,16 +170,19 @@ int main(int argc, char** argv) {
     app.run<SegmentedReductionNDRange<int>>();
     app.run<SegmentedReductionNDRange<long long>>();
     app.run<SegmentedReductionNDRange<float>>();
-    if(app.deviceSupportsFP64())
-      app.run<SegmentedReductionNDRange<double>>();
+    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+      if(app.deviceSupportsFP64())
+        app.run<SegmentedReductionNDRange<double>>();
+    }
   }
 
   app.run<SegmentedReductionHierarchical<short>>();
   app.run<SegmentedReductionHierarchical<int>>();
   app.run<SegmentedReductionHierarchical<long long>>();
   app.run<SegmentedReductionHierarchical<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<SegmentedReductionHierarchical<double>>();
-
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<SegmentedReductionHierarchical<double>>();
+  }
   return 0;
 }

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -200,7 +200,10 @@ private:
 
 int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
-  if(app.deviceSupportsFP64())
-    app.run<Polybench_Fdtd2d>();
+
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<Polybench_Fdtd2d>();
+  }
   return 0;
 }

--- a/single-kernel/kmeans.cpp
+++ b/single-kernel/kmeans.cpp
@@ -124,7 +124,9 @@ public:
 int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   app.run<KmeansBench<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<KmeansBench<double>>();
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<KmeansBench<double>>();
+  }
   return 0;
 }

--- a/single-kernel/lin_reg_coeff.cpp
+++ b/single-kernel/lin_reg_coeff.cpp
@@ -191,8 +191,10 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   if(app.shouldRunNDRangeKernels()) {
     app.run<LinearRegressionCoeffBench<float>>();
-    if(app.deviceSupportsFP64())
-      app.run<LinearRegressionCoeffBench<double>>();
+    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+      if(app.deviceSupportsFP64())
+        app.run<LinearRegressionCoeffBench<double>>();
+    }
   }
   return 0;
 }

--- a/single-kernel/lin_reg_error.cpp
+++ b/single-kernel/lin_reg_error.cpp
@@ -127,7 +127,9 @@ public:
 int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   app.run<LinearRegressionBench<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<LinearRegressionBench<double>>();
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<LinearRegressionBench<double>>();
+  }
   return 0;
 }

--- a/single-kernel/nbody.cpp
+++ b/single-kernel/nbody.cpp
@@ -262,8 +262,7 @@ public:
   using typename NBody<float_type>::particle_type;
   using typename NBody<float_type>::vector_type;
 
-  NBodyNDRange(const BenchmarkArgs& _args) : NBody<float_type> { _args }
-  {}
+  NBodyNDRange(const BenchmarkArgs& _args) : NBody<float_type>{_args} {}
 
 
   void run() { this->submitNDRange(this->particles_buf.get(), this->velocities_buf.get()); }
@@ -283,8 +282,7 @@ public:
   using typename NBody<float_type>::particle_type;
   using typename NBody<float_type>::vector_type;
 
-  NBodyHierarchical(const BenchmarkArgs& _args) : NBody<float_type> { _args }
-  {}
+  NBodyHierarchical(const BenchmarkArgs& _args) : NBody<float_type>{_args} {}
 
 
   void run() { this->submitHierarchical(this->particles_buf.get(), this->velocities_buf.get()); }
@@ -302,13 +300,16 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
 
   app.run<NBodyHierarchical<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<NBodyHierarchical<double>>();
-
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<NBodyHierarchical<double>>();
+  }
   if(app.shouldRunNDRangeKernels()) {
     app.run<NBodyNDRange<float>>();
-    if(app.deviceSupportsFP64())
-      app.run<NBodyNDRange<double>>();
+    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+      if(app.deviceSupportsFP64())
+        app.run<NBodyNDRange<double>>();
+    }
   }
 
   return 0;

--- a/single-kernel/scalar_prod.cpp
+++ b/single-kernel/scalar_prod.cpp
@@ -212,15 +212,18 @@ int main(int argc, char** argv) {
     app.run<ScalarProdBench<int, true>>();
     app.run<ScalarProdBench<long long, true>>();
     app.run<ScalarProdBench<float, true>>();
-    if(app.deviceSupportsFP64())
-      app.run<ScalarProdBench<double, true>>();
+    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+      if(app.deviceSupportsFP64())
+        app.run<ScalarProdBench<double, true>>();
+    }
   }
 
   app.run<ScalarProdBench<int, false>>();
   app.run<ScalarProdBench<long long, false>>();
   app.run<ScalarProdBench<float, false>>();
-  if(app.deviceSupportsFP64())
-    app.run<ScalarProdBench<double, false>>();
-
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<ScalarProdBench<double, false>>();
+  }
   return 0;
 }

--- a/single-kernel/vec_add.cpp
+++ b/single-kernel/vec_add.cpp
@@ -82,7 +82,9 @@ int main(int argc, char** argv) {
   app.run<VecAddBench<int>>();
   app.run<VecAddBench<long long>>();
   app.run<VecAddBench<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<VecAddBench<double>>();
+  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if(app.deviceSupportsFP64())
+      app.run<VecAddBench<double>>();
+  }
   return 0;
 }


### PR DESCRIPTION
This PR adds a cmake variable `SYCL_BENCH_ENABLE_FP64_BENCHMARKS` to explicitly enable FP64 benchmarks. The variable is set to `1` or `0` with a define in the C++ code.  
This is required as AoT compilation can fail if the target device does not support FP64 (e.g. desktop Intel GPUs), thus the current way of querying the FP64 aspect at runtime is not sufficient.