### PR TITLE
Add `--warmup-run` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Benchmarks support the following command line arguments:
 * `--verification-range=<x,y,z>` - Specify the size of the 3D range that should be used for verifying results. Note: Most benchmarks do not implement this feature. Default: `1,1,1`
 * `--no-verification` - disable verification entirely
 * `--no-ndrange-kernels` - do not run kernels based on ndrange parallel for
+* `--warmup-run` - run benchmarks once before evaluation to discard possible "warmup" times, e.g., JIT compilation
 
 ## Usage
 Clone sycl-bench repo 

--- a/bin/run-suite
+++ b/bin/run-suite
@@ -34,6 +34,7 @@ def create_log_range(begin, end):
     --verification-range=<x,y,z> - Specify the size of the 3D range that should be used for verifying results. Note: Most benchmarks do not implement this feature. Default: 1,1,1
     --no-verification - disable verification entirely
     --no-ndrange-kernels - do not run kernels based on ndrange parallel for
+    --warmup-run - run benchmarks once before evaluation to discard possible "warmup" times, e.g., JIT compilation
 '''
 output_file = "./sycl-bench.csv"
 
@@ -130,7 +131,9 @@ profiles = {
   'default': default_profile,
   'quicktest' : construct_profile({}, max_allowed_runtime=1.0),
   'cpu' : construct_profile({'--device':'cpu'}),
+  'cpu-warmup' : construct_profile({'--device':'cpu'},['--warmup-run']),
   'gpu' : construct_profile({'--device':'gpu'}),
+  'gpu-warmup' : construct_profile({'--device':'gpu'},['--warmup-run']),
   'cpu-noverify' : construct_profile({'--device':'cpu'},['--no-verification']),
   'cpu-nondrange' : construct_profile({'--device':'cpu'},['--no-ndrange-kernels']),
   'cpu-noverify-nondrange' : construct_profile({'--device':'cpu'},['--no-verification','--no-ndrange-kernels']),

--- a/include/command_line.h
+++ b/include/command_line.h
@@ -166,6 +166,7 @@ struct BenchmarkArgs
   // can be used to query additional benchmark specific information from the command line
   CommandLine cli;
   std::shared_ptr<ResultConsumer> result_consumer;
+  bool warmup_run;
 };
 
 class CUDASelector : public cl::sycl::device_selector {
@@ -193,6 +194,11 @@ public:
     std::size_t num_runs = cli_parser.getOrDefault<std::size_t>("--num-runs", 5);
 
     std::string device_type = cli_parser.getOrDefault<std::string>("--device", "default");
+    bool warmup_run = cli_parser.isFlagSet("--warmup-run");
+    if (warmup_run) {
+      // Make drop of first run transparent to the user
+      ++num_runs;
+    }
     cl::sycl::queue q = getQueue(device_type);
 
     bool verification_enabled = true;
@@ -216,7 +222,8 @@ public:
                                              verification_begin,
                                              verification_range},
                          cli_parser,
-                         result_consumer};
+                         result_consumer,
+                         warmup_run};
   }
 
 private:

--- a/include/time_metrics.h
+++ b/include/time_metrics.h
@@ -75,7 +75,11 @@ public:
     for(const auto& name : allTimings) {
       if(unavailableTimings.count(name) == 0) {
         std::vector<double> resultsSeconds;
-        std::transform(timingResults.at(name).begin(), timingResults.at(name).end(), std::back_inserter(resultsSeconds),
+        auto timesBegin = timingResults.at(name).begin();
+        if (args.warmup_run) {
+          ++timesBegin;
+        }
+        std::transform(timesBegin, timingResults.at(name).end(), std::back_inserter(resultsSeconds),
             [](auto r) { return r.count() / 1.0e9; });
         std::sort(resultsSeconds.begin(), resultsSeconds.end());
 


### PR DESCRIPTION
Add option to perform a first "warmup" run that will not be taken into consideration to omit possible JIT overhead in the evaluation.

Also add two additional profiles to `run-suite`: `cpu-warmup` and `gpu-warmup`.