### PR TITLE
Add CPack capabilities to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ if(CMAKE_GENERATOR STREQUAL "Ninja")
   set(COMPUTECPP_USER_FLAGS "${COMPUTECPP_USER_FLAGS} -fdiagnostics-color=always")
 endif()
 
+include(InstallRequiredSystemLibraries)
+include(CPack)
+
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_SOURCE_DIR}/polybench/common)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ Run individual tests as such:
 $ ./arith --device=cpu --output=output.csv
 ```
 
+## Packaging
+
+SYCL-Bench provides a CMake target `package` (and `package_source`) to package a SYCL-Bench installation. Users can configure what generators to use to build the packages by (un-)setting the different `CPACK_BINARY_<GENNAME>` CMake flags and then build the enabled packages by building the `package` target:
+
+```
+cmake -Bbuild -DCPACK_BINARY_TZ=OFF -DCPACK_BINARY_TGZ=ON -DCPACK_BINARY_DEB=OFF
+cmake --build build --target package
+```
+
+For more information, check the [CPack documentation](https://cmake.org/cmake/help/latest/module/CPack.html) for the relevant CMake version.
+
+Packages built via the `package` target will contain all files contained in a SYCL-Bench installation (binaries, scripts, benchmark inputs). Packages built via the `package_source` target will additionally contain the source files.
+
 ## Attribution
 If you use SYCL-Bench, please cite the following papers:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ ./arith --device=cpu --output=output.csv
 
 ## Packaging
 
-SYCL-Bench provides a CMake target `package` (and `package_source`) to package a SYCL-Bench installation. Users can configure what generators to use to build the packages by setting `CPACK_BINARY_<GENNAME>` CMake flag and then build the enabled packages by building the `package` target:
+SYCL-Bench provides a CMake target `package` (and `package_source`) to package a SYCL-Bench installation. Users can configure what generators to use to build the packages by passing a semicolon-separated list of generators to use to the `CPACK_GENERATOR` CMake flag and then build the enabled packages by building the `package` target:
 
 ```
 cmake -Bbuild -DCPACK_GENERATOR="TGZ;ZIP"

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ $ ./arith --device=cpu --output=output.csv
 
 ## Packaging
 
-SYCL-Bench provides a CMake target `package` (and `package_source`) to package a SYCL-Bench installation. Users can configure what generators to use to build the packages by (un-)setting the different `CPACK_BINARY_<GENNAME>` CMake flags and then build the enabled packages by building the `package` target:
+SYCL-Bench provides a CMake target `package` (and `package_source`) to package a SYCL-Bench installation. Users can configure what generators to use to build the packages by setting `CPACK_BINARY_<GENNAME>` CMake flag and then build the enabled packages by building the `package` target:
 
 ```
-cmake -Bbuild -DCPACK_BINARY_TZ=OFF -DCPACK_BINARY_TGZ=ON -DCPACK_BINARY_DEB=OFF
+cmake -Bbuild -DCPACK_GENERATOR="TGZ;ZIP"
 cmake --build build --target package
 ```
 


### PR DESCRIPTION
Add several `CPACK_*` options and `package` and `package_source` targets to configure and build SYCL-Bench packages.