### PR TITLE
Fix `median` benchmark image load

### DIFF
--- a/single-kernel/median.cpp
+++ b/single-kernel/median.cpp
@@ -41,7 +41,7 @@ public:
   void setup() {
     size = args.problem_size; // input size defined by the user
     input.resize(size * size); 
-    load_bitmap_mirrored("../../share/Brommy.bmp", size, input);
+    load_bitmap_mirrored("../share/Brommy.bmp", size, input);
     output.resize(size * size);
 
     input_buf.initialize(args.device_queue, input.data(), s::range<2>(size, size));    


### PR DESCRIPTION
The `median` bennchmark was not loading the image correctly. 
- moved Brommy.bmp to `share` directory
- median benchmark now loads the picture using a path local to the build directory