### PR TITLE
Add `BenchmarkArgs` to `getBenchmarkName`

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -41,7 +41,7 @@ public:
   template<typename... Args>
   void run(Args&&... additionalArgs)
   {
-    args.result_consumer->proceedToBenchmark(Benchmark{args, additionalArgs...}.getBenchmarkName());
+    args.result_consumer->proceedToBenchmark(Benchmark{args, additionalArgs...}.getBenchmarkName(args));
 
     args.result_consumer->consumeResult(
       "problem-size", std::to_string(args.problem_size));
@@ -200,7 +200,7 @@ public:
   void run(AdditionalArgs&&... additional_args)
   {
     try {
-      const auto name = Benchmark{args, additional_args...}.getBenchmarkName();
+      const auto name = Benchmark{args, additional_args...}.getBenchmarkName(args);
       if(benchmark_names.count(name) == 0) {
         benchmark_names.insert(name);
       } else {

--- a/micro/DRAM.cpp
+++ b/micro/DRAM.cpp
@@ -87,7 +87,7 @@ public:
     return true;
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "MicroBench_DRAM_";
     name << ReadableTypename<DataT>::name;

--- a/micro/arith.cpp
+++ b/micro/arith.cpp
@@ -77,7 +77,7 @@ public:
     return true;
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "MicroBench_Arith_";
     name << ReadableTypename<DataT>::name << "_";

--- a/micro/host_device_bandwidth.cpp
+++ b/micro/host_device_bandwidth.cpp
@@ -224,7 +224,7 @@ public:
     return false;
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "MicroBench_HostDeviceBandwidth_";
     name << Dims << "D_";

--- a/micro/local_mem.cpp
+++ b/micro/local_mem.cpp
@@ -63,7 +63,7 @@ public:
     })); // submit
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "MicroBench_LocalMem_";
     name << ReadableTypename<DATA_TYPE>::name << "_";

--- a/micro/pattern_L2.cpp
+++ b/micro/pattern_L2.cpp
@@ -48,7 +48,7 @@ public:
     })); // submit
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "MicroBench_L2_";
     name << ReadableTypename<DATA_TYPE>::name << "_";

--- a/micro/sf.cpp
+++ b/micro/sf.cpp
@@ -72,7 +72,7 @@ public:
     return true;
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "MicroBench_sf_";
     name << ReadableTypename<DataT>::name << "_";

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -209,7 +209,7 @@ public:
     this->submit_ndrange(events);
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "Pattern_Reduction_NDRange_";
     name << ReadableTypename<T>::name;
@@ -231,7 +231,7 @@ public:
     // wait_and_throw() here
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "Pattern_Reduction_Hierarchical_";
     name << ReadableTypename<T>::name;

--- a/pattern/segmentedreduction.cpp
+++ b/pattern/segmentedreduction.cpp
@@ -162,7 +162,7 @@ public:
     // wait_and_throw() here
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "Pattern_SegmentedReduction_NDRange_";
     name << ReadableTypename<T>::name;
@@ -184,7 +184,7 @@ public:
     // wait_and_throw() here
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "Pattern_SegmentedReduction_Hierarchical_";
     name << ReadableTypename<T>::name;

--- a/polybench/2DConvolution.cpp
+++ b/polybench/2DConvolution.cpp
@@ -98,7 +98,7 @@ class Polybench_2DConvolution {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_2DConvolution"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_2DConvolution"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/2mm.cpp
+++ b/polybench/2mm.cpp
@@ -143,7 +143,7 @@ class Polybench_2mm {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_2mm"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_2mm"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/3DConvolution.cpp
+++ b/polybench/3DConvolution.cpp
@@ -117,7 +117,7 @@ class Polybench_3DConvolution {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_3DConvolution"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_3DConvolution"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/3mm.cpp
+++ b/polybench/3mm.cpp
@@ -180,7 +180,7 @@ class Polybench_3mm {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_3mm"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_3mm"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/atax.cpp
+++ b/polybench/atax.cpp
@@ -114,7 +114,7 @@ class Polybench_Atax {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Atax"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Atax"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/bicg.cpp
+++ b/polybench/bicg.cpp
@@ -121,7 +121,7 @@ class Polybench_Bicg {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Bicg"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Bicg"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/correlation.cpp
+++ b/polybench/correlation.cpp
@@ -208,7 +208,7 @@ class Polybench_Correlation {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Correlation"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Correlation"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/covariance.cpp
+++ b/polybench/covariance.cpp
@@ -150,7 +150,7 @@ public:
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Covariance"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Covariance"; }
 
 private:
 	BenchmarkArgs args;

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -179,7 +179,7 @@ class Polybench_Fdtd2d {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Fdtd2d"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Fdtd2d"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/gemm.cpp
+++ b/polybench/gemm.cpp
@@ -114,7 +114,7 @@ class Polybench_Gemm {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Gemm"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Gemm"; }
 
 private:
 	BenchmarkArgs args;

--- a/polybench/gesummv.cpp
+++ b/polybench/gesummv.cpp
@@ -116,7 +116,7 @@ public:
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Gesummv"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Gesummv"; }
 
 private:
 	BenchmarkArgs args;

--- a/polybench/gramschmidt.cpp
+++ b/polybench/gramschmidt.cpp
@@ -141,7 +141,7 @@ class Polybench_Gramschmidt {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Gramschmidt"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Gramschmidt"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/mvt.cpp
+++ b/polybench/mvt.cpp
@@ -121,7 +121,7 @@ class Polybench_Mvt {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Mvt"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Mvt"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/syr2k.cpp
+++ b/polybench/syr2k.cpp
@@ -110,7 +110,7 @@ class Polybench_Syr2k {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Syr2k"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Syr2k"; }
 
   private:
 	BenchmarkArgs args;

--- a/polybench/syrk.cpp
+++ b/polybench/syrk.cpp
@@ -106,7 +106,7 @@ class Polybench_Syrk {
 		return true;
 	}
 
-	static std::string getBenchmarkName() { return "Polybench_Syrk"; }
+	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Syrk"; }
 
   private:
 	BenchmarkArgs args;

--- a/runtime/blocked_transform.cpp
+++ b/runtime/blocked_transform.cpp
@@ -108,7 +108,7 @@ public:
     return true;
   }
   
-  std::string getBenchmarkName() {
+  std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "Runtime_BlockedTransform_iter_";
     name << Num_iterations << "_blocksize_";

--- a/runtime/dag_task_throughput_independent.cpp
+++ b/runtime/dag_task_throughput_independent.cpp
@@ -130,7 +130,7 @@ public:
     submit_single_task();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_IndependentDAGTaskThroughput_SingleTask";
   }
 };
@@ -146,7 +146,7 @@ public:
     submit_basic_parallel_for();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_IndependentDAGTaskThroughput_BasicParallelFor";
   }
 };
@@ -162,7 +162,7 @@ public:
     submit_ndrange_parallel_for();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_IndependentDAGTaskThroughput_NDRangeParallelFor";
   }
 };
@@ -178,7 +178,7 @@ public:
     submit_hierarchical_parallel_for();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_IndependentDAGTaskThroughput_HierarchicalParallelFor";
   }
 };

--- a/runtime/dag_task_throughput_sequential.cpp
+++ b/runtime/dag_task_throughput_sequential.cpp
@@ -123,7 +123,7 @@ public:
     submit_single_task();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_DAGTaskThroughput_SingleTask";
   }
 };
@@ -139,7 +139,7 @@ public:
     submit_basic_parallel_for();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_DAGTaskThroughput_BasicParallelFor";
   }
 };
@@ -155,7 +155,7 @@ public:
     submit_ndrange_parallel_for();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_DAGTaskThroughput_NDRangeParallelFor";
   }
 };
@@ -171,7 +171,7 @@ public:
     submit_hierarchical_parallel_for();
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Runtime_DAGTaskThroughput_HierarchicalParallelFor";
   }
 };

--- a/runtime/matmulchain.cpp
+++ b/runtime/matmulchain.cpp
@@ -86,7 +86,7 @@ public:
 		multiply(args.device_queue, mat_p_buf.get(), mat_q_buf.get(), mat_res_buf.get(), mat_size);
 	}
 
-  static std::string getBenchmarkName() { return "MatmulChain"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "MatmulChain"; }
 
   bool verify(VerificationSetting &ver) {
 		// Triggers writeback

--- a/single-kernel/kmeans.cpp
+++ b/single-kernel/kmeans.cpp
@@ -114,7 +114,7 @@ public:
     return pass;
   }
 
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "Kmeans_";
     name << ReadableTypename<T>::name;

--- a/single-kernel/lin_reg_coeff.cpp
+++ b/single-kernel/lin_reg_coeff.cpp
@@ -182,7 +182,7 @@ T reduce(std::vector<cl::sycl::event>& events, s::buffer<T, 1> &input_buf) {
     return pass;
   }
   
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "LinearRegressionCoeff_";
     name << ReadableTypename<T>::name;

--- a/single-kernel/lin_reg_error.cpp
+++ b/single-kernel/lin_reg_error.cpp
@@ -120,7 +120,7 @@ public:
     return compare(expected_output, args.problem_size, 0.000001);
   }
   
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "LinearRegression_";
     name << ReadableTypename<T>::name;

--- a/single-kernel/median.cpp
+++ b/single-kernel/median.cpp
@@ -182,7 +182,7 @@ public:
 }
 
 
-static std::string getBenchmarkName() {
+static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "MedianFilter";
   }
 

--- a/single-kernel/mol_dyn.cpp
+++ b/single-kernel/mol_dyn.cpp
@@ -141,7 +141,7 @@ public:
     return pass;
   }
   
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "MolecularDynamics";
   }
 };

--- a/single-kernel/nbody.cpp
+++ b/single-kernel/nbody.cpp
@@ -282,7 +282,7 @@ public:
     this->submitNDRange(this->particles_buf.get(), this->velocities_buf.get());
   }
 
-  std::string getBenchmarkName() {
+  std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "NBody_NDRange_";
     name << ReadableTypename<float_type>::name;
@@ -306,7 +306,7 @@ public:
     this->submitHierarchical(this->particles_buf.get(), this->velocities_buf.get());
   }
 
-  std::string getBenchmarkName() {
+  std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "NBody_Hierarchical_";
     name << ReadableTypename<float_type>::name;

--- a/single-kernel/scalar_prod.cpp
+++ b/single-kernel/scalar_prod.cpp
@@ -214,7 +214,7 @@ public:
     return pass;
   }
   
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "ScalarProduct_";
     name << (Use_ndrange ? "NDRange_" : "Hierarchical_");

--- a/single-kernel/sobel.cpp
+++ b/single-kernel/sobel.cpp
@@ -139,7 +139,7 @@ public:
   }
 
 
-  static std::string getBenchmarkName() { return "Sobel3"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Sobel3"; }
 
 }; // SobelBench class
 

--- a/single-kernel/sobel5.cpp
+++ b/single-kernel/sobel5.cpp
@@ -149,7 +149,7 @@ public:
 }
 
 
-static std::string getBenchmarkName() {
+static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Sobel5";
   }
 

--- a/single-kernel/sobel7.cpp
+++ b/single-kernel/sobel7.cpp
@@ -148,7 +148,7 @@ public:
   }
 
 
-static std::string getBenchmarkName() {
+static std::string getBenchmarkName(BenchmarkArgs& args) {
     return "Sobel7";
   }
 

--- a/single-kernel/vec_add.cpp
+++ b/single-kernel/vec_add.cpp
@@ -75,7 +75,7 @@ public:
     return pass;
   }
   
-  static std::string getBenchmarkName() {
+  static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "VectorAddition_";
     name << ReadableTypename<T>::name;


### PR DESCRIPTION
This PR adds the `BenchmarkArgs` parameter to the`getBenchmarkName` function.
Before, if one had a kernel using additionals command line parameters there was no way to customize the kernel name when writing the output results. While it does not affect the benchmark suite structure, it does help to differentiate kernels  when running separate benchmark instances .

While a better solution would be to provide the user a way to define additional output metric to pass to the result consumer, this should provide a quick and effective way to do it