### PR TITLE
Fix DPC++ Intel GPU cmake + default cmake arguments 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Due to CMake limitations, hipSYCL requires C++ standard to be set manually
-set(CMAKE_SYCL_FLAGS "${CMAKE_SYCL_FLAGS} -std=c++17")
+# Default build flags
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG -fno-omit-frame-pointer" CACHE STRING "Flags used by the C++ compiler during debug builds." FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -ffast-math" CACHE STRING "Flags used by the C++ compiler during release builds." FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -march=native -ffast-math -g -fno-omit-frame-pointer" CACHE STRING "Flags used by the C++ compiler during release builds with debug info." FORCE)
+
 
 if(CMAKE_GENERATOR STREQUAL "Ninja")
   set(CMAKE_SYCL_FLAGS "${CMAKE_SYCL_FLAGS} -fdiagnostics-color=always")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,12 +66,10 @@ elseif(SYCL_IMPL STREQUAL "dpcpp")
   endif()
 
   if(DPCPP_WITH_LZ_BACKEND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl-targets=spir64_gen")
-
     set(LZ_ARCH "" CACHE STRING "Level Zero device architecture e.g. acm-g10")
 
     if(NOT LZ_ARCH STREQUAL "")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xsycl-target-backend \"-device ${LZ_ARCH}\"")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl-targets=${LZ_ARCH}")
     endif()
   endif()
 elseif(SYCL_IMPL STREQUAL "triSYCL")


### PR DESCRIPTION
- Fixed the command line parameter string for Intel GPUs on DPC++
- Added some default cmake arguments for debug, release and ReleaseWithDebugInfo