### PR TITLE
Removed duplicated default build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,6 @@ if(CMAKE_GENERATOR STREQUAL "Ninja")
 	set(COMPUTECPP_USER_FLAGS "${COMPUTECPP_USER_FLAGS} -fdiagnostics-color=always")
 endif()
 
-# Default build flags
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG -fno-omit-frame-pointer" CACHE STRING "Flags used by the C++ compiler during debug builds." FORCE)
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -march=native -ffast-math" CACHE STRING "Flags used by the C++ compiler during release builds." FORCE)
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -march=native -ffast-math -g -fno-omit-frame-pointer" CACHE STRING "Flags used by the C++ compiler during release builds with debug info." FORCE)
-
 if(SYCL_BENCH_ENABLE_QUEUE_PROFILING)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSYCL_BENCH_ENABLE_QUEUE_PROFILING")
 endif()


### PR DESCRIPTION
Somewhere in time, the default build flags got duplicated in the CmakeLists.txt.
This PR removes the duplicated one.