### PR TITLE
Add check for `timingResults` size when using `--warmup-run`

### DIFF
--- a/include/time_metrics.h
+++ b/include/time_metrics.h
@@ -76,7 +76,8 @@ public:
       if(unavailableTimings.count(name) == 0) {
         std::vector<double> resultsSeconds;
         auto timesBegin = timingResults.at(name).begin();
-        if (args.warmup_run) {
+        // If verification is enabled and fails, only the warmup run is executed.
+        if (timingResults.size() > 1 && args.warmup_run) {
           ++timesBegin;
         }
         std::transform(timesBegin, timingResults.at(name).end(), std::back_inserter(resultsSeconds),


### PR DESCRIPTION
When using the `--warmup-run` flag with verification on, if the verification fails only the warmup run is executed. This was leading to segfault as the warmup run was skipping the first execution in every case. This PR adds a check before skipping the run.
Fixes #75. 