### PR TITLE
Add cmake checks for SYCL features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(sycl-bench)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake ${PROJECT_SOURCE_DIR}/cmake/has-features)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ set(benchmarks
 if (SYCL_BENCH_HAS_SPEC_CONSTANTS)
   list(APPEND benchmarks sycl2020/spec_constants/spec_constant_convolution.cpp)
 endif()
-if (SYCL_BENCH_HAS_KERNEL_REDUCTION)
+if (SYCL_BENCH_HAS_KERNEL_REDUCTIONS)
   list(APPEND benchmarks sycl2020/kernel_reduction/kernel_reduction.cpp)
 endif()
 if (SYCL_BENCH_HAS_GROUP_ALGORITHMS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(sycl-bench)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake ${PROJECT_SOURCE_DIR}/cmake/has-features)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -89,6 +89,8 @@ elseif(SYCL_IMPL STREQUAL "triSYCL")
 	find_package(TriSYCL MODULE REQUIRED)
 endif()
 
+include(HasFeatures)
+
 set(benchmarks
   micro/arith.cpp
   micro/DRAM.cpp
@@ -130,18 +132,25 @@ set(benchmarks
   polybench/syrk.cpp
 
   # compiletime/compiletime.cpp
-  sycl2020/spec_constants/spec_constant_convolution.cpp  
   sycl2020/atomics/atomic_reduction.cpp
-  sycl2020/kernel_reduction/kernel_reduction.cpp
-  sycl2020/group_algorithms/reduce_over_group.cpp
   sycl2020/USM/usm_accessors_latency.cpp
   sycl2020/USM/usm_instr_mix.cpp
   sycl2020/USM/usm_pinned_overhead.cpp
   sycl2020/USM/usm_allocation_latency.cpp
 )
+# Selectively add benchmarks based on some SYCL 2020 features
+if (SYCL_BENCH_HAS_SPEC_CONSTANTS)
+  list(APPEND benchmarks sycl2020/spec_constants/spec_constant_convolution.cpp)
+endif()
+if (SYCL_BENCH_HAS_KERNEL_REDUCTION)
+list(APPEND benchmarks sycl2020/kernel_reduction/kernel_reduction.cpp)
+endif()
+if (SYCL_BENCH_HAS_GROUP_ALGORITHMS)
+  list(APPEND benchmarks sycl2020/group_algorithms/reduce_over_group.cpp)
+endif()
 
 # Setting variables
-add_compile_definitions(SYCL_BENCH_ENABLE_FP64_BENCHMARKS=$<BOOL:${SYCL_BENCH_ENABLE_FP64_BENCHMARKS}>)
+add_compile_definitions(SYCL_BENCH_ENABLE_FP64_BENCHMARKS=$<BOOL:${SYCL_BENCH_HAS_FP64_SUPPORT}>)
 
 foreach(benchmark IN LISTS benchmarks)
 	get_filename_component(target ${benchmark} NAME_WE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,6 @@ include(CPack)
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_SOURCE_DIR}/polybench/common)
 
-# SYCL Bench variables
-set(SYCL_BENCH_ENABLE_FP64_BENCHMARKS "ON" CACHE STRING "Enable FP64 benchmarks [ON]")
-
 set(supported_implementations
 	AdaptiveCpp
 	dpcpp
@@ -84,6 +81,7 @@ elseif(SYCL_IMPL STREQUAL "triSYCL")
 	find_package(TriSYCL MODULE REQUIRED)
 endif()
 
+# Check if SYCL implementation implements the required SYCL features
 include(HasFeatures)
 
 set(benchmarks
@@ -138,14 +136,14 @@ if (SYCL_BENCH_HAS_SPEC_CONSTANTS)
   list(APPEND benchmarks sycl2020/spec_constants/spec_constant_convolution.cpp)
 endif()
 if (SYCL_BENCH_HAS_KERNEL_REDUCTION)
-list(APPEND benchmarks sycl2020/kernel_reduction/kernel_reduction.cpp)
+  list(APPEND benchmarks sycl2020/kernel_reduction/kernel_reduction.cpp)
 endif()
 if (SYCL_BENCH_HAS_GROUP_ALGORITHMS)
   list(APPEND benchmarks sycl2020/group_algorithms/reduce_over_group.cpp)
 endif()
 
 # Setting variables
-add_compile_definitions(SYCL_BENCH_ENABLE_FP64_BENCHMARKS=$<BOOL:${SYCL_BENCH_HAS_FP64_SUPPORT}>)
+add_compile_definitions(SYCL_BENCH_HAS_FP64_SUPPORT=$<BOOL:${SYCL_BENCH_HAS_FP64_SUPPORT}>)
 
 foreach(benchmark IN LISTS benchmarks)
 	get_filename_component(target ${benchmark} NAME_WE)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ mkdir build && cd build
 
 Compile with CMake
 ```
-$ cmake -DSYCL_IMPL=[target SYCL implementation] [other compiler arguments] ..
+$ cmake -DSYCL_IMPL=[target SYCL implementation] [-DSYCL_BENCH_HAS_FP64_SUPPORT=ON|OFF] [other compiler arguments] ..
 $ cmake --build .
 $ sudo make install
 ```

--- a/cmake/HasFeatures.cmake
+++ b/cmake/HasFeatures.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3) # TODO: No idea with one is the actual minimum
+cmake_minimum_required(VERSION 3.25) # TODO: No idea with one is the actual minimum
 
 macro(check_feature VAR FILENAME)
     if(NOT DEFINED SYCL_BENCH_HAS_${VAR})

--- a/cmake/HasFeatures.cmake
+++ b/cmake/HasFeatures.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.25) # TODO: No idea with one is the actual minimum
-
 macro(check_feature VAR FILENAME)
     if(NOT DEFINED SYCL_BENCH_HAS_${VAR})
         try_compile(SYCL_BENCH_HAS_${VAR} ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/has-features/src/${FILENAME} 
@@ -13,8 +11,7 @@ macro(check_feature VAR FILENAME)
     else()
         set(RES OFF)
     endif()
-    message(STATUS "${VAR}: ${RES}")    
-
+    message(STATUS "${VAR}: ${RES}")
 endmacro()
 
 message(STATUS "Checking for SYCL features....")

--- a/cmake/HasFeatures.cmake
+++ b/cmake/HasFeatures.cmake
@@ -15,7 +15,7 @@ macro(check_feature VAR FILENAME)
 endmacro()
 
 message(STATUS "Checking for SYCL features....")
-check_feature(KERNEL_REDUCTION kernel_reduction_dummy.cpp)
+check_feature(KERNEL_REDUCTIONS kernel_reduction_dummy.cpp)
 check_feature(SPEC_CONSTANTS spec_constants_dummy.cpp)
 check_feature(GROUP_ALGORITHMS group_algorithms_dummy.cpp)
 check_feature(FP64_SUPPORT fp64_support_dummy.cpp)

--- a/cmake/HasFeatures.cmake
+++ b/cmake/HasFeatures.cmake
@@ -17,7 +17,7 @@ macro(check_feature VAR FILENAME)
 
 endmacro()
 
-message(STATUS "Checking for SYCL 2020 features....")
+message(STATUS "Checking for SYCL features....")
 check_feature(KERNEL_REDUCTION kernel_reduction_dummy.cpp)
 check_feature(SPEC_CONSTANTS spec_constants_dummy.cpp)
 check_feature(GROUP_ALGORITHMS group_algorithms_dummy.cpp)

--- a/cmake/has-features/HasFeatures.cmake
+++ b/cmake/has-features/HasFeatures.cmake
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.4.3) # TODO: No idea with one is the actual minimum
+
+macro(check_feature VAR FILENAME)
+    if(NOT DEFINED SYCL_BENCH_HAS_${VAR})
+        try_compile(SYCL_BENCH_HAS_${VAR} ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/has-features/src/${FILENAME} 
+            CMAKE_FLAGS ${CMAKE_CXX_FLAGS}
+            OUTPUT_VARIABLE OUTPUT_VAR
+        )
+    endif()
+
+    if (SYCL_BENCH_HAS_${VAR})
+        set(RES ON)
+    else()
+        set(RES OFF)
+    endif()
+    message(STATUS "${VAR}: ${RES}")    
+
+endmacro()
+
+message(STATUS "Checking for SYCL 2020 features....")
+check_feature(KERNEL_REDUCTION kernel_reduction_dummy.cpp)
+check_feature(SPEC_CONSTANTS spec_constants_dummy.cpp)
+check_feature(GROUP_ALGORITHMS group_algorithms_dummy.cpp)
+check_feature(FP64_SUPPORT fp64_support_dummy.cpp)

--- a/cmake/has-features/src/fp64_support_dummy.cpp
+++ b/cmake/has-features/src/fp64_support_dummy.cpp
@@ -1,13 +1,11 @@
 #include <sycl/sycl.hpp>
 
-int main(){
-    sycl::queue q;
-    sycl::buffer<double> x(1);
+int main() {
+  sycl::queue q;
+  sycl::buffer<double> x(1);
 
-    q.submit([&](sycl::handler& cgh){
-        sycl::accessor a(x, cgh, sycl::read_write);
-        cgh.parallel_for<class dummy>(sycl::range<1>(1), [=](sycl::id<1> idx){
-            a[idx] = 0;
-        });
-    });
+  q.submit([&](sycl::handler& cgh) {
+    sycl::accessor a(x, cgh, sycl::read_write);
+    cgh.parallel_for<class dummy>(sycl::range<1>(1), [=](sycl::id<1> idx) { a[idx] = 0; });
+  });
 }

--- a/cmake/has-features/src/fp64_support_dummy.cpp
+++ b/cmake/has-features/src/fp64_support_dummy.cpp
@@ -1,0 +1,13 @@
+#include <sycl/sycl.hpp>
+
+int main(){
+    sycl::queue q;
+    sycl::buffer<double> x(1);
+
+    q.submit([&](sycl::handler& cgh){
+        sycl::accessor a(x, cgh, sycl::read_write);
+        cgh.parallel_for<class dummy>(sycl::range<1>(1), [=](sycl::id<1> idx){
+            a[idx] = 0;
+        });
+    });
+}

--- a/cmake/has-features/src/group_algorithms_dummy.cpp
+++ b/cmake/has-features/src/group_algorithms_dummy.cpp
@@ -1,0 +1,12 @@
+#include<sycl/sycl.hpp>
+
+int main(){
+    sycl::queue q;
+
+    q.submit([&](sycl::handler& cgh){
+       q.parallel_for(sycl::nd_range<1>{{1},{1}}, [=](sycl::nd_item<1> item){
+        //call only the group algorithms used in SYCL-Bench
+        sycl::reduce_over_group(item.get_group(), 0, sycl::plus<int>{});  
+       });
+    });
+}

--- a/cmake/has-features/src/group_algorithms_dummy.cpp
+++ b/cmake/has-features/src/group_algorithms_dummy.cpp
@@ -1,12 +1,12 @@
-#include<sycl/sycl.hpp>
+#include <sycl/sycl.hpp>
 
-int main(){
-    sycl::queue q;
+int main() {
+  sycl::queue q;
 
-    q.submit([&](sycl::handler& cgh){
-       q.parallel_for(sycl::nd_range<1>{{1},{1}}, [=](sycl::nd_item<1> item){
-        //call only the group algorithms used in SYCL-Bench
-        sycl::reduce_over_group(item.get_group(), 0, sycl::plus<int>{});  
-       });
+  q.submit([&](sycl::handler& cgh) {
+    q.parallel_for(sycl::nd_range<1>{{1}, {1}}, [=](sycl::nd_item<1> item) {
+      // call only the group algorithms used in SYCL-Bench
+      sycl::reduce_over_group(item.get_group(), 0, sycl::plus<int>{});
     });
+  });
 }

--- a/cmake/has-features/src/kernel_reduction_dummy.cpp
+++ b/cmake/has-features/src/kernel_reduction_dummy.cpp
@@ -1,0 +1,17 @@
+#include <sycl/sycl.hpp>
+
+int main(){
+    sycl::queue q;
+    sycl::buffer<int> x(1);
+    q.submit([&](sycl::handler& cgh){
+        #ifdef __ACPP__
+                auto r = sycl::reduction(x.template get_access<sycl::access_mode::read_write>(cgh), sycl::plus<int>{});
+        #else
+                auto r = sycl::reduction(x,cgh, sycl::plus<int>{});
+        #endif
+
+        cgh.parallel_for(sycl::range<1>{1}, r, [=](sycl::id<1> idx, auto& op){
+            op.combine(1);
+        });
+    });
+}

--- a/cmake/has-features/src/kernel_reduction_dummy.cpp
+++ b/cmake/has-features/src/kernel_reduction_dummy.cpp
@@ -1,17 +1,15 @@
 #include <sycl/sycl.hpp>
 
-int main(){
-    sycl::queue q;
-    sycl::buffer<int> x(1);
-    q.submit([&](sycl::handler& cgh){
-        #ifdef __ACPP__
-                auto r = sycl::reduction(x.template get_access<sycl::access_mode::read_write>(cgh), sycl::plus<int>{});
-        #else
-                auto r = sycl::reduction(x,cgh, sycl::plus<int>{});
-        #endif
+int main() {
+  sycl::queue q;
+  sycl::buffer<int> x(1);
+  q.submit([&](sycl::handler& cgh) {
+#ifdef __ACPP__
+    auto r = sycl::reduction(x.template get_access<sycl::access_mode::read_write>(cgh), sycl::plus<int>{});
+#else
+    auto r = sycl::reduction(x, cgh, sycl::plus<int>{});
+#endif
 
-        cgh.parallel_for(sycl::range<1>{1}, r, [=](sycl::id<1> idx, auto& op){
-            op.combine(1);
-        });
-    });
+    cgh.parallel_for(sycl::range<1>{1}, r, [=](sycl::id<1> idx, auto& op) { op.combine(1); });
+  });
 }

--- a/cmake/has-features/src/spec_constants_dummy.cpp
+++ b/cmake/has-features/src/spec_constants_dummy.cpp
@@ -1,0 +1,21 @@
+#include <sycl/sycl.hpp>
+
+#ifndef __ACPP__
+
+static constexpr sycl::specialization_id<int> x;
+
+int main(){
+    sycl::queue q;
+
+    q.submit([&](sycl::handler& cgh){
+        cgh.set_specialization_constant<x>(5);
+    });
+}
+
+#else
+
+int main(){
+    sycl::specialized<int> x(5);
+}
+
+#endif

--- a/cmake/has-features/src/spec_constants_dummy.cpp
+++ b/cmake/has-features/src/spec_constants_dummy.cpp
@@ -4,18 +4,16 @@
 
 static constexpr sycl::specialization_id<int> x;
 
-int main(){
-    sycl::queue q;
+int main() {
+  sycl::queue q;
 
-    q.submit([&](sycl::handler& cgh){
-        cgh.set_specialization_constant<x>(5);
-    });
+  q.submit([&](sycl::handler& cgh) { cgh.set_specialization_constant<x>(5); });
 }
 
 #else
 
-int main(){
-    sycl::specialized<int> x(5);
-}
+// AdaptiveCpp implements sycl::specialized instead of spec constants
+
+int main() { sycl::specialized<int> x(5); }
 
 #endif

--- a/include/benchmark_hook.h
+++ b/include/benchmark_hook.h
@@ -3,17 +3,16 @@
 
 #include "result_consumer.h"
 
-class BenchmarkHook
-{
+class BenchmarkHook {
 public:
   virtual void atInit() = 0;
   virtual void preSetup() = 0;
-  virtual void postSetup()= 0;
+  virtual void postSetup() = 0;
   virtual void preKernel() = 0;
   virtual void postKernel() = 0;
   virtual void emitResults(ResultConsumer&) {}
 
-  virtual ~BenchmarkHook(){}
+  virtual ~BenchmarkHook() {}
 };
 
 #endif

--- a/include/bitmap.h
+++ b/include/bitmap.h
@@ -87,7 +87,7 @@ public:
 //////////////////////////////////////////////////////////////////////////////////
 #include <fstream>
 #include <iostream>
-//#include "bitmap.h"
+// #include "bitmap.h"
 #include <cstdlib>
 
 typedef unsigned char uchar_t;

--- a/include/common.h
+++ b/include/common.h
@@ -53,7 +53,7 @@ public:
       // verification fails
       for(std::size_t run = 0; run < args.num_runs && all_runs_pass; ++run) {
         Benchmark b(args, additionalArgs...);
-        
+
         for(auto h : hooks) h->preSetup();
 
         b.setup();

--- a/include/nv_energy_meas.h
+++ b/include/nv_energy_meas.h
@@ -1,4 +1,4 @@
-#pragma once 
+#pragma once
 
 // NVML energy measurmeent
 // TODO

--- a/include/result_consumer.h
+++ b/include/result_consumer.h
@@ -1,22 +1,20 @@
 #ifndef RESULT_CONSUMER_HPP
 #define RESULT_CONSUMER_HPP
 
+#include <algorithm>
 #include <cassert>
 #include <fstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <algorithm>
 
-class ResultConsumer
-{
+class ResultConsumer {
 public:
   virtual void proceedToBenchmark(const std::string& name) = 0;
   // Register a result in the result consumer
-  virtual void consumeResult(const std::string& result_name,
-                            const std::string& result,
-                            const std::string& unit = "") = 0;
+  virtual void consumeResult(
+      const std::string& result_name, const std::string& result, const std::string& unit = "") = 0;
 
   // Guarantees that the results have been emitted to the output
   // as specified by the ResultConsumer implementation
@@ -25,32 +23,23 @@ public:
   // Discards the current benchmark's results, useful e.g. in case of errors.
   virtual void discard() {}
 
-  virtual ~ResultConsumer(){}
-  
+  virtual ~ResultConsumer() {}
 };
 
-class OstreamResultConsumer : public ResultConsumer
-{
+class OstreamResultConsumer : public ResultConsumer {
   std::ostream& output;
   std::string name;
 
 public:
-  OstreamResultConsumer(std::ostream& ostr)
-  : output{ostr}
-  {}
+  OstreamResultConsumer(std::ostream& ostr) : output{ostr} {}
 
-  virtual void proceedToBenchmark(const std::string& benchmark_name) override
-  {
+  virtual void proceedToBenchmark(const std::string& benchmark_name) override {
     name = benchmark_name;
-    output << "********** Results for " << name 
-           << "**********" << std::endl;
-    
+    output << "********** Results for " << name << "**********" << std::endl;
   }
 
-  virtual void consumeResult(const std::string& result_name,
-                            const std::string& result,
-                            const std::string& unit = "") override
-  {
+  virtual void consumeResult(
+      const std::string& result_name, const std::string& result, const std::string& unit = "") override {
     output << result_name << ": " << result;
     if(!unit.empty()) {
       output << " [" << unit << "]";
@@ -58,63 +47,48 @@ public:
     output << std::endl;
   }
 
-  virtual void flush() override
-  {
-  }
+  virtual void flush() override {}
 };
 
 // TODO ResultConsumer that appends to a csv
-class AppendingCsvResultConsumer : public ResultConsumer
-{
+class AppendingCsvResultConsumer : public ResultConsumer {
 public:
   using benchmark_data = std::unordered_map<std::string, std::string>;
 
-  AppendingCsvResultConsumer(const std::string& filename)
-  : output{filename, std::ios::app}
-  {}
+  AppendingCsvResultConsumer(const std::string& filename) : output{filename, std::ios::app} {}
 
-  virtual void proceedToBenchmark(const std::string& benchmark_name) override
-  {
-    currentBenchmark = benchmark_name;
-  }
+  virtual void proceedToBenchmark(const std::string& benchmark_name) override { currentBenchmark = benchmark_name; }
 
-  virtual void consumeResult(const std::string& result_name,
-                            const std::string& result,
-                            const std::string& unit = "") override
-  {
+  virtual void consumeResult(
+      const std::string& result_name, const std::string& result, const std::string& unit = "") override {
     data[currentBenchmark][result_name] = result;
   }
 
-  virtual void flush() override
-  {
+  virtual void flush() override {
     std::unordered_set<std::string> columns;
 
-    for(const auto& benchmark: data) {
+    for(const auto& benchmark : data) {
       for(auto entry : benchmark.second) {
         columns.insert(entry.first);
       }
     }
 
     std::vector<std::string> sorted_columns;
-    for(auto c : columns)
-      sorted_columns.push_back(c);
+    for(auto c : columns) sorted_columns.push_back(c);
     // To make sure order of columns is deterministic
-    std::sort(sorted_columns.begin(),sorted_columns.end());
+    std::sort(sorted_columns.begin(), sorted_columns.end());
 
     output << "# Benchmark name";
-    for(auto c : sorted_columns)
-      output << "," << c;
+    for(auto c : sorted_columns) output << "," << c;
     output << std::endl;
 
     for(const auto& benchmark : data) {
       output << benchmark.first;
-      for(auto c : sorted_columns)
-        output << "," << benchmark.second.at(c);
+      for(auto c : sorted_columns) output << "," << benchmark.second.at(c);
       output << std::endl;
     }
 
     data.clear();
-    
   }
 
   void discard() override {
@@ -132,4 +106,3 @@ private:
 };
 
 #endif
-

--- a/include/time_metrics.h
+++ b/include/time_metrics.h
@@ -76,7 +76,7 @@ public:
       if(unavailableTimings.count(name) == 0) {
         std::vector<double> resultsSeconds;
         auto timesBegin = timingResults.at(name).begin();
-        if (args.warmup_run) {
+        if(args.warmup_run) {
           ++timesBegin;
         }
         std::transform(timesBegin, timingResults.at(name).end(), std::back_inserter(resultsSeconds),

--- a/include/type_traits.h
+++ b/include/type_traits.h
@@ -1,14 +1,15 @@
 #ifndef TYPE_TRAITS_H
 #define TYPE_TRAITS_H
 
-template<class T>
-struct ReadableTypename
-{};
+template <class T>
+struct ReadableTypename {};
 
-#define MAKE_READABLE_TYPENAME(T, str) \
-template<> \
-struct ReadableTypename<T> \
-{ static const char* name; }; const char* ReadableTypename<T>::name = str;
+#define MAKE_READABLE_TYPENAME(T, str)                                                                                 \
+  template <>                                                                                                          \
+  struct ReadableTypename<T> {                                                                                         \
+    static const char* name;                                                                                           \
+  };                                                                                                                   \
+  const char* ReadableTypename<T>::name = str;
 
 MAKE_READABLE_TYPENAME(char, "int8")
 MAKE_READABLE_TYPENAME(unsigned char, "uint8")

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,12 +1,12 @@
 #include <array>
 #include <type_traits.h>
 
-template<std::size_t ...Idx, typename F>
-void loop_impl(std::integer_sequence<std::size_t, Idx...>, F&& f){
-	(f(std::integral_constant<std::size_t, Idx>{}), ...);
-} 
+template <std::size_t... Idx, typename F>
+void loop_impl(std::integer_sequence<std::size_t, Idx...>, F&& f) {
+  (f(std::integral_constant<std::size_t, Idx>{}), ...);
+}
 
-template<std::size_t count, typename F>
-void loop(F&& f){
-	loop_impl(std::make_index_sequence<count>{}, std::forward<F>(f));
+template <std::size_t count, typename F>
+void loop(F&& f) {
+  loop_impl(std::make_index_sequence<count>{}, std::forward<F>(f));
 }

--- a/micro/DRAM.cpp
+++ b/micro/DRAM.cpp
@@ -103,11 +103,9 @@ int main(int argc, char** argv) {
   app.run<MicroBenchDRAM<float, 2>>();
   app.run<MicroBenchDRAM<float, 3>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64()) {
-      app.run<MicroBenchDRAM<double, 1>>();
-      app.run<MicroBenchDRAM<double, 2>>();
-      app.run<MicroBenchDRAM<double, 3>>();
-    }
+    app.run<MicroBenchDRAM<double, 1>>();
+    app.run<MicroBenchDRAM<double, 2>>();
+    app.run<MicroBenchDRAM<double, 3>>();
   }
   return 0;
 }

--- a/micro/DRAM.cpp
+++ b/micro/DRAM.cpp
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
   app.run<MicroBenchDRAM<float, 1>>();
   app.run<MicroBenchDRAM<float, 2>>();
   app.run<MicroBenchDRAM<float, 3>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<MicroBenchDRAM<double, 1>>();
     app.run<MicroBenchDRAM<double, 2>>();
     app.run<MicroBenchDRAM<double, 3>>();

--- a/micro/arith.cpp
+++ b/micro/arith.cpp
@@ -92,8 +92,7 @@ int main(int argc, char** argv) {
   app.run<MicroBenchArithmetic<int>>();
   app.run<MicroBenchArithmetic<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<MicroBenchArithmetic<double>>();
+    app.run<MicroBenchArithmetic<double>>();
   }
   return 0;
 }

--- a/micro/arith.cpp
+++ b/micro/arith.cpp
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
 
   app.run<MicroBenchArithmetic<int>>();
   app.run<MicroBenchArithmetic<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<MicroBenchArithmetic<double>>();
   }
   return 0;

--- a/micro/local_mem.cpp
+++ b/micro/local_mem.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
   app.run<MicroBenchLocalMemory<float, compute_iters>>();
 
   // double precision
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<MicroBenchLocalMemory<double, compute_iters>>();
   }
   return 0;

--- a/micro/local_mem.cpp
+++ b/micro/local_mem.cpp
@@ -101,8 +101,7 @@ int main(int argc, char** argv) {
 
   // double precision
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<MicroBenchLocalMemory<double, compute_iters>>();
+    app.run<MicroBenchLocalMemory<double, compute_iters>>();
   }
   return 0;
 }

--- a/micro/pattern_L2.cpp
+++ b/micro/pattern_L2.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
 
 
   // double precision
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<MicroBenchL2<double, 1>>();
     app.run<MicroBenchL2<double, 2>>();
     app.run<MicroBenchL2<double, 4>>();

--- a/micro/pattern_L2.cpp
+++ b/micro/pattern_L2.cpp
@@ -74,13 +74,11 @@ int main(int argc, char** argv) {
 
   // double precision
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64()) {
-      app.run<MicroBenchL2<double, 1>>();
-      app.run<MicroBenchL2<double, 2>>();
-      app.run<MicroBenchL2<double, 4>>();
-      app.run<MicroBenchL2<double, 8>>();
-      app.run<MicroBenchL2<double, 16>>();
-    }
+    app.run<MicroBenchL2<double, 1>>();
+    app.run<MicroBenchL2<double, 2>>();
+    app.run<MicroBenchL2<double, 4>>();
+    app.run<MicroBenchL2<double, 8>>();
+    app.run<MicroBenchL2<double, 16>>();
   }
   return 0;
 }

--- a/micro/sf.cpp
+++ b/micro/sf.cpp
@@ -86,8 +86,7 @@ int main(int argc, char** argv) {
 
   app.run<MicroBenchSpecialFunc<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<MicroBenchSpecialFunc<double>>();
+    app.run<MicroBenchSpecialFunc<double>>();
   }
   return 0;
 }

--- a/micro/sf.cpp
+++ b/micro/sf.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
 
   app.run<MicroBenchSpecialFunc<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<MicroBenchSpecialFunc<double>>();
   }
   return 0;

--- a/pattern/prefixsum.cpp
+++ b/pattern/prefixsum.cpp
@@ -1,1 +1,1 @@
-TODO: SYCL code with a prefix sum
+TODO : SYCL code with a prefix sum

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -212,8 +212,7 @@ int main(int argc, char** argv) {
     app.run<ReductionNDRange<long long>>();
     app.run<ReductionNDRange<float>>();
     if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-      if(app.deviceSupportsFP64())
-        app.run<ReductionNDRange<double>>();
+      app.run<ReductionNDRange<double>>();
     }
   }
   // app.run< ReductionHierarchical<short>>();
@@ -221,8 +220,7 @@ int main(int argc, char** argv) {
   app.run<ReductionHierarchical<long long>>();
   app.run<ReductionHierarchical<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<ReductionHierarchical<double>>();
+    app.run<ReductionHierarchical<double>>();
   }
   return 0;
 }

--- a/pattern/reduction.cpp
+++ b/pattern/reduction.cpp
@@ -211,7 +211,7 @@ int main(int argc, char** argv) {
     app.run<ReductionNDRange<int>>();
     app.run<ReductionNDRange<long long>>();
     app.run<ReductionNDRange<float>>();
-    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
       app.run<ReductionNDRange<double>>();
     }
   }
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
   app.run<ReductionHierarchical<int>>();
   app.run<ReductionHierarchical<long long>>();
   app.run<ReductionHierarchical<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<ReductionHierarchical<double>>();
   }
   return 0;

--- a/pattern/scan.cpp
+++ b/pattern/scan.cpp
@@ -1,1 +1,1 @@
-TODO: SYCL code with a scan
+TODO : SYCL code with a scan

--- a/pattern/segmentedreduction.cpp
+++ b/pattern/segmentedreduction.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
     app.run<SegmentedReductionNDRange<int>>();
     app.run<SegmentedReductionNDRange<long long>>();
     app.run<SegmentedReductionNDRange<float>>();
-    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
       app.run<SegmentedReductionNDRange<double>>();
     }
   }
@@ -179,7 +179,7 @@ int main(int argc, char** argv) {
   app.run<SegmentedReductionHierarchical<int>>();
   app.run<SegmentedReductionHierarchical<long long>>();
   app.run<SegmentedReductionHierarchical<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<SegmentedReductionHierarchical<double>>();
   }
   return 0;

--- a/pattern/segmentedreduction.cpp
+++ b/pattern/segmentedreduction.cpp
@@ -171,8 +171,7 @@ int main(int argc, char** argv) {
     app.run<SegmentedReductionNDRange<long long>>();
     app.run<SegmentedReductionNDRange<float>>();
     if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-      if(app.deviceSupportsFP64())
-        app.run<SegmentedReductionNDRange<double>>();
+      app.run<SegmentedReductionNDRange<double>>();
     }
   }
 
@@ -181,8 +180,7 @@ int main(int argc, char** argv) {
   app.run<SegmentedReductionHierarchical<long long>>();
   app.run<SegmentedReductionHierarchical<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<SegmentedReductionHierarchical<double>>();
+    app.run<SegmentedReductionHierarchical<double>>();
   }
   return 0;
 }

--- a/pattern/segmentedscan.cpp
+++ b/pattern/segmentedscan.cpp
@@ -1,1 +1,1 @@
-TODO: SYCL code with segmented scan
+TODO : SYCL code with segmented scan

--- a/polybench/2DConvolution.cpp
+++ b/polybench/2DConvolution.cpp
@@ -100,7 +100,7 @@ public:
     return true;
   }
 
-	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_2DConvolution"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_2DConvolution"; }
 
 private:
   BenchmarkArgs args;

--- a/polybench/atax.cpp
+++ b/polybench/atax.cpp
@@ -115,7 +115,7 @@ public:
     return true;
   }
 
-	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Atax"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Atax"; }
 
 private:
   BenchmarkArgs args;

--- a/polybench/common/polybenchUtilFuncts.h
+++ b/polybench/common/polybenchUtilFuncts.h
@@ -14,34 +14,33 @@
 #define SMALL_FLOAT_VAL 0.00000001f
 
 double rtclock() {
-	struct timezone Tzp;
-	struct timeval Tp;
-	int stat;
-	stat = gettimeofday(&Tp, &Tzp);
-	if(stat != 0) printf("Error return from gettimeofday: %d", stat);
-	return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+  struct timezone Tzp;
+  struct timeval Tp;
+  int stat;
+  stat = gettimeofday(&Tp, &Tzp);
+  if(stat != 0)
+    printf("Error return from gettimeofday: %d", stat);
+  return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
 }
 
 
 float absVal(float a) {
-	if(a < 0) {
-		return (a * -1);
-	} else {
-		return a;
-	}
+  if(a < 0) {
+    return (a * -1);
+  } else {
+    return a;
+  }
 }
 
 
 float percentDiff(double val1, double val2) {
-	if((absVal(val1) < 0.01) && (absVal(val2) < 0.01)) {
-		return 0.0f;
-	} else {
-		return 100.0f * (absVal(absVal(val1 - val2) / absVal(val1 + SMALL_FLOAT_VAL)));
-	}
+  if((absVal(val1) < 0.01) && (absVal(val2) < 0.01)) {
+    return 0.0f;
+  } else {
+    return 100.0f * (absVal(absVal(val1 - val2) / absVal(val1 + SMALL_FLOAT_VAL)));
+  }
 }
 
-static bool shouldDoCpu(void) {
-	return getenv("SYCL_BENCH_SKIP_CPU") == NULL;
-}
+static bool shouldDoCpu(void) { return getenv("SYCL_BENCH_SKIP_CPU") == NULL; }
 
 #endif // POLYBENCH_UTIL_FUNCTS_H

--- a/polybench/covariance.cpp
+++ b/polybench/covariance.cpp
@@ -154,7 +154,7 @@ public:
     return true;
   }
 
-	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Covariance"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Covariance"; }
 
 private:
   BenchmarkArgs args;

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -202,8 +202,7 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
 
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<Polybench_Fdtd2d>();
+    app.run<Polybench_Fdtd2d>();
   }
   return 0;
 }

--- a/polybench/fdtd2d.cpp
+++ b/polybench/fdtd2d.cpp
@@ -201,7 +201,7 @@ private:
 int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
 
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<Polybench_Fdtd2d>();
   }
   return 0;

--- a/polybench/gemm.cpp
+++ b/polybench/gemm.cpp
@@ -115,7 +115,7 @@ public:
     return true;
   }
 
-	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Gemm"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Gemm"; }
 
 private:
   BenchmarkArgs args;

--- a/polybench/gesummv.cpp
+++ b/polybench/gesummv.cpp
@@ -118,7 +118,7 @@ public:
     return true;
   }
 
-	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Gesummv"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Gesummv"; }
 
 private:
   BenchmarkArgs args;

--- a/polybench/syr2k.cpp
+++ b/polybench/syr2k.cpp
@@ -111,7 +111,7 @@ public:
     return true;
   }
 
-	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Syr2k"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Syr2k"; }
 
 private:
   BenchmarkArgs args;

--- a/polybench/syrk.cpp
+++ b/polybench/syrk.cpp
@@ -107,7 +107,7 @@ public:
     return true;
   }
 
-	static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Syrk"; }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Polybench_Syrk"; }
 
 private:
   BenchmarkArgs args;

--- a/runtime/blocked_transform.cpp
+++ b/runtime/blocked_transform.cpp
@@ -90,7 +90,7 @@ public:
 
     return true;
   }
-  
+
   std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "Runtime_BlockedTransform_iter_";

--- a/runtime/dag_task_throughput_independent.cpp
+++ b/runtime/dag_task_throughput_independent.cpp
@@ -101,9 +101,7 @@ public:
 
   void run() { submit_single_task(); }
 
-  static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "Runtime_IndependentDAGTaskThroughput_SingleTask";
-  }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Runtime_IndependentDAGTaskThroughput_SingleTask"; }
 };
 
 class IndependentDagTaskThroughputBasicPF : public IndependentDagTaskThroughput {

--- a/runtime/dag_task_throughput_sequential.cpp
+++ b/runtime/dag_task_throughput_sequential.cpp
@@ -96,9 +96,7 @@ public:
 
   void run() { submit_single_task(); }
 
-  static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "Runtime_DAGTaskThroughput_SingleTask";
-  }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Runtime_DAGTaskThroughput_SingleTask"; }
 };
 
 
@@ -108,9 +106,7 @@ public:
 
   void run() { submit_basic_parallel_for(); }
 
-  static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "Runtime_DAGTaskThroughput_BasicParallelFor";
-  }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Runtime_DAGTaskThroughput_BasicParallelFor"; }
 };
 
 
@@ -120,9 +116,7 @@ public:
 
   void run() { submit_ndrange_parallel_for(); }
 
-  static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "Runtime_DAGTaskThroughput_NDRangeParallelFor";
-  }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Runtime_DAGTaskThroughput_NDRangeParallelFor"; }
 };
 
 

--- a/runtime/short_long.cpp
+++ b/runtime/short_long.cpp
@@ -1,1 +1,2 @@
-TODO SYCL code with multiple tasks A -> b1 ... bn -> D and A -> C -> D where b1...bn are short task and C is a long task, so that runtime capabilities of kernel overlapping is evaluated
+TODO SYCL code with multiple tasks A->b1... bn->D and A->C->D where b1... bn are short task and C is a long task,
+    so that runtime capabilities of kernel overlapping is evaluated

--- a/single-kernel/kmeans.cpp
+++ b/single-kernel/kmeans.cpp
@@ -125,8 +125,7 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   app.run<KmeansBench<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<KmeansBench<double>>();
+    app.run<KmeansBench<double>>();
   }
   return 0;
 }

--- a/single-kernel/kmeans.cpp
+++ b/single-kernel/kmeans.cpp
@@ -124,7 +124,7 @@ public:
 int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   app.run<KmeansBench<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<KmeansBench<double>>();
   }
   return 0;

--- a/single-kernel/lin_reg_coeff.cpp
+++ b/single-kernel/lin_reg_coeff.cpp
@@ -191,7 +191,7 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   if(app.shouldRunNDRangeKernels()) {
     app.run<LinearRegressionCoeffBench<float>>();
-    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
       app.run<LinearRegressionCoeffBench<double>>();
     }
   }

--- a/single-kernel/lin_reg_coeff.cpp
+++ b/single-kernel/lin_reg_coeff.cpp
@@ -178,7 +178,7 @@ public:
 
     return pass;
   }
-  
+
   static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "LinearRegressionCoeff_";
@@ -192,8 +192,7 @@ int main(int argc, char** argv) {
   if(app.shouldRunNDRangeKernels()) {
     app.run<LinearRegressionCoeffBench<float>>();
     if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-      if(app.deviceSupportsFP64())
-        app.run<LinearRegressionCoeffBench<double>>();
+      app.run<LinearRegressionCoeffBench<double>>();
     }
   }
   return 0;

--- a/single-kernel/lin_reg_error.cpp
+++ b/single-kernel/lin_reg_error.cpp
@@ -115,7 +115,7 @@ public:
 
     return compare(expected_output, args.problem_size, 0.000001);
   }
-  
+
   static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "LinearRegression_";
@@ -128,8 +128,7 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   app.run<LinearRegressionBench<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<LinearRegressionBench<double>>();
+    app.run<LinearRegressionBench<double>>();
   }
   return 0;
 }

--- a/single-kernel/lin_reg_error.cpp
+++ b/single-kernel/lin_reg_error.cpp
@@ -127,7 +127,7 @@ public:
 int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
   app.run<LinearRegressionBench<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<LinearRegressionBench<double>>();
   }
   return 0;

--- a/single-kernel/median.cpp
+++ b/single-kernel/median.cpp
@@ -39,7 +39,7 @@ public:
 
   void setup() {
     size = args.problem_size; // input size defined by the user
-    input.resize(size * size); 
+    input.resize(size * size);
     load_bitmap_mirrored("../share/Brommy.bmp", size, input);
     output.resize(size * size);
 
@@ -176,9 +176,7 @@ public:
   }
 
 
-static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "MedianFilter";
-  }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "MedianFilter"; }
 
 }; // MedianFilterBench class
 

--- a/single-kernel/mol_dyn.cpp
+++ b/single-kernel/mol_dyn.cpp
@@ -134,10 +134,8 @@ public:
     }
     return pass;
   }
-  
-  static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "MolecularDynamics";
-  }
+
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "MolecularDynamics"; }
 };
 
 int main(int argc, char** argv) {

--- a/single-kernel/nbody.cpp
+++ b/single-kernel/nbody.cpp
@@ -301,14 +301,12 @@ int main(int argc, char** argv) {
 
   app.run<NBodyHierarchical<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<NBodyHierarchical<double>>();
+    app.run<NBodyHierarchical<double>>();
   }
   if(app.shouldRunNDRangeKernels()) {
     app.run<NBodyNDRange<float>>();
     if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-      if(app.deviceSupportsFP64())
-        app.run<NBodyNDRange<double>>();
+      app.run<NBodyNDRange<double>>();
     }
   }
 

--- a/single-kernel/nbody.cpp
+++ b/single-kernel/nbody.cpp
@@ -300,12 +300,12 @@ int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
 
   app.run<NBodyHierarchical<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<NBodyHierarchical<double>>();
   }
   if(app.shouldRunNDRangeKernels()) {
     app.run<NBodyNDRange<float>>();
-    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
       app.run<NBodyNDRange<double>>();
     }
   }

--- a/single-kernel/perlin.cpp
+++ b/single-kernel/perlin.cpp
@@ -1,1 +1,1 @@
-TODO: import Perlin noise from the Insieme OpenCL benchmark
+TODO : import Perlin noise from the Insieme OpenCL benchmark

--- a/single-kernel/scalar_prod.cpp
+++ b/single-kernel/scalar_prod.cpp
@@ -196,7 +196,7 @@ public:
 
     return pass;
   }
-  
+
   static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "ScalarProduct_";
@@ -213,8 +213,7 @@ int main(int argc, char** argv) {
     app.run<ScalarProdBench<long long, true>>();
     app.run<ScalarProdBench<float, true>>();
     if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-      if(app.deviceSupportsFP64())
-        app.run<ScalarProdBench<double, true>>();
+      app.run<ScalarProdBench<double, true>>();
     }
   }
 
@@ -222,8 +221,7 @@ int main(int argc, char** argv) {
   app.run<ScalarProdBench<long long, false>>();
   app.run<ScalarProdBench<float, false>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<ScalarProdBench<double, false>>();
+    app.run<ScalarProdBench<double, false>>();
   }
   return 0;
 }

--- a/single-kernel/scalar_prod.cpp
+++ b/single-kernel/scalar_prod.cpp
@@ -212,7 +212,7 @@ int main(int argc, char** argv) {
     app.run<ScalarProdBench<int, true>>();
     app.run<ScalarProdBench<long long, true>>();
     app.run<ScalarProdBench<float, true>>();
-    if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+    if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
       app.run<ScalarProdBench<double, true>>();
     }
   }
@@ -220,7 +220,7 @@ int main(int argc, char** argv) {
   app.run<ScalarProdBench<int, false>>();
   app.run<ScalarProdBench<long long, false>>();
   app.run<ScalarProdBench<float, false>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<ScalarProdBench<double, false>>();
   }
   return 0;

--- a/single-kernel/sobel5.cpp
+++ b/single-kernel/sobel5.cpp
@@ -137,12 +137,10 @@ public:
       }
     }
     return pass;
-}
-
-
-static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "Sobel5";
   }
+
+
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Sobel5"; }
 
 }; // SobelBench class
 

--- a/single-kernel/sobel7.cpp
+++ b/single-kernel/sobel7.cpp
@@ -142,9 +142,7 @@ public:
   }
 
 
-static std::string getBenchmarkName(BenchmarkArgs& args) {
-    return "Sobel7";
-  }
+  static std::string getBenchmarkName(BenchmarkArgs& args) { return "Sobel7"; }
 
 }; // SobelBench class
 

--- a/single-kernel/vec_add.cpp
+++ b/single-kernel/vec_add.cpp
@@ -68,7 +68,7 @@ public:
     }
     return pass;
   }
-  
+
   static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
     name << "VectorAddition_";
@@ -83,8 +83,7 @@ int main(int argc, char** argv) {
   app.run<VecAddBench<long long>>();
   app.run<VecAddBench<float>>();
   if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
-    if(app.deviceSupportsFP64())
-      app.run<VecAddBench<double>>();
+    app.run<VecAddBench<double>>();
   }
   return 0;
 }

--- a/single-kernel/vec_add.cpp
+++ b/single-kernel/vec_add.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
   app.run<VecAddBench<int>>();
   app.run<VecAddBench<long long>>();
   app.run<VecAddBench<float>>();
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     app.run<VecAddBench<double>>();
   }
   return 0;

--- a/sycl2020/USM/usm_accessors_latency.cpp
+++ b/sycl2020/USM/usm_accessors_latency.cpp
@@ -50,8 +50,8 @@ public:
   using base = LatencyBenchmark<DATA_TYPE, in_order>;
   using base::args;
   using base::base;
-  using base::getQueue;
   using base::getNDRange;
+  using base::getQueue;
   using base::getRange;
   using base::kernel_launches_num;
 
@@ -106,14 +106,13 @@ protected:
   using base = LatencyBenchmark<DATA_TYPE, in_order>;
   using base::args;
   using base::base;
-  using base::getQueue;
   using base::getNDRange;
+  using base::getQueue;
   using base::getRange;
   using base::kernel_launches_num;
 
 public:
-  USMLatency(const BenchmarkArgs& args, const size_t kernel_launches_num)
-      : base(args, kernel_launches_num) {}
+  USMLatency(const BenchmarkArgs& args, const size_t kernel_launches_num) : base(args, kernel_launches_num) {}
 
   void setup() {
     buff_A.initialize(getQueue(), getRange());

--- a/sycl2020/USM/usm_allocation_latency.cpp
+++ b/sycl2020/USM/usm_allocation_latency.cpp
@@ -32,7 +32,8 @@ public:
     queue.fill(buffer, DATA_TYPE{1}, args.problem_size).wait();
     DATA_TYPE* host_ptr = buffer;
     if constexpr(usm_type == sycl::usm::alloc::device) {
-      host_ptr = static_cast<DATA_TYPE*>(sycl::malloc(args.problem_size * sizeof(DATA_TYPE), args.device_queue, sycl::usm::alloc::host));
+      host_ptr = static_cast<DATA_TYPE*>(
+          sycl::malloc(args.problem_size * sizeof(DATA_TYPE), args.device_queue, sycl::usm::alloc::host));
       queue.copy(buffer, host_ptr, args.problem_size).wait();
     }
 

--- a/sycl2020/USM/usm_instr_mix.cpp
+++ b/sycl2020/USM/usm_instr_mix.cpp
@@ -19,7 +19,7 @@ The benchmark is run with 4 different configurations:
   - USM allocations with device memory
   - USM allocations with host memory
   - USM allocations with shared memory
-  - USM allocations with shared memory and prefetching  
+  - USM allocations with shared memory and prefetching
 
 The benchmark uses 2 additional configurations:
   - USM allocations with initialization

--- a/sycl2020/USM/usm_pinned_overhead.cpp
+++ b/sycl2020/USM/usm_pinned_overhead.cpp
@@ -48,7 +48,7 @@ public:
     if constexpr(!include_init) {
       init();
     }
-    buffer = (DATA_TYPE*) sycl::malloc_device(args.problem_size * sizeof(DATA_TYPE), queue);
+    buffer = (DATA_TYPE*)sycl::malloc_device(args.problem_size * sizeof(DATA_TYPE), queue);
   }
 
   void run(std::vector<sycl::event>& events) {
@@ -58,10 +58,9 @@ public:
     }
 
     for(size_t i = 0; i < num_copies; i++) {
-      if constexpr(direction == HOST_DEVICE){
+      if constexpr(direction == HOST_DEVICE) {
         events.push_back(queue.copy(host_memory, buffer, args.problem_size));
-      }
-      else{
+      } else {
         events.push_back(queue.copy(buffer, host_memory, args.problem_size));
       }
     }
@@ -75,22 +74,22 @@ public:
 
   static std::string getBenchmarkName(BenchmarkArgs& args) {
     std::stringstream name;
-    const size_t num_copies= args.cli.getOrDefault("--num-copies", d_num_copies);
-    
+    const size_t num_copies = args.cli.getOrDefault("--num-copies", d_num_copies);
+
     name << "USM_Pinned_Overhead_";
     name << ReadableTypename<DATA_TYPE>::name << "_";
     name << (direction == HOST_DEVICE ? "HostDevice" : "DeviceHost") << "_";
     name << (use_pinned_memory ? "Pinned" : "NonPinned") << "_";
-    name << (include_init ? "Init" : "NoInit") << "_"; 
+    name << (include_init ? "Init" : "NoInit") << "_";
     name << num_copies;
-    
+
     return name.str();
   }
 };
 
 int main(int argc, char** argv) {
   BenchmarkApp app(argc, argv);
-  const size_t num_copies= app.getArgs().cli.getOrDefault("--num-copies", d_num_copies);
+  const size_t num_copies = app.getArgs().cli.getOrDefault("--num-copies", d_num_copies);
 
   app.run<USMPinnedOverhead<float, false, HOST_DEVICE, true>>(num_copies);
   app.run<USMPinnedOverhead<float, true, HOST_DEVICE, true>>(num_copies);

--- a/sycl2020/atomics/atomic_reduction.cpp
+++ b/sycl2020/atomics/atomic_reduction.cpp
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
   app.run<ReductionAtomic<int>>();
   app.run<ReductionAtomic<long long>>();
   app.run<ReductionAtomic<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<ReductionAtomic<double>>();
+
+  app.run<ReductionAtomic<double>>();
   return 0;
 }

--- a/sycl2020/group_algorithms/reduce_over_group.cpp
+++ b/sycl2020/group_algorithms/reduce_over_group.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv) {
   app.run<ReduceGroupAlgorithm<int>>();
   app.run<ReduceGroupAlgorithm<long long>>();
   app.run<ReduceGroupAlgorithm<float>>();
-  if(app.deviceSupportsFP64())
-    app.run<ReduceGroupAlgorithm<double>>();
+
+  app.run<ReduceGroupAlgorithm<double>>();
   return 0;
 }

--- a/sycl2020/kernel_reduction/kernel_reduction.cpp
+++ b/sycl2020/kernel_reduction/kernel_reduction.cpp
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
   runOperators<int>(app);
   runOperators<long long>(app);
   runOperators<float>(app);
-  if(app.deviceSupportsFP64())
-    runOperators<double>(app);
+
+  runOperators<double>(app);
   return 0;
 }

--- a/sycl2020/spec_constants/spec_constant_convolution.cpp
+++ b/sycl2020/spec_constants/spec_constant_convolution.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
   runAccessVariants<int>(app);
   runAccessVariants<long long>(app);
   runAccessVariants<float>(app);
-  if constexpr(SYCL_BENCH_ENABLE_FP64_BENCHMARKS) {
+  if constexpr(SYCL_BENCH_HAS_FP64_SUPPORT) {
     runAccessVariants<double>(app);
   }
   return 0;


### PR DESCRIPTION
Previously if a SYCL2020 feature was not implemented by a compiler, the benchmark compilation was just failing.
This PR adds cmake checks to cover three SYCL2020 features:
- Specialization constants (or `sycl::specialized` for AdaptiveCpp)
- Kernel reductions
- Group algorithms
In addition, it also adds a check for FP64 compatibility to selectively enable benchmark that uses FP64 types.
The check structure can also be expanded in the future with additional features check if necessary.